### PR TITLE
Add domestic/international flight filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import requests
 import os
 import json
 import csv
+import re
 import unicodedata
 from dotenv import load_dotenv
 
@@ -89,10 +90,13 @@ def _load_local_airports() -> list:
         for a in data if isinstance(data, list) else []:
             code = (a.get("code") or "").upper().strip()
             if code and code not in seen:
+                raw_label = (a.get("label") or code).strip()
+                m = re.search(r',\s*([A-Z]{2})\s*$', raw_label)
                 clean.append({
                     "code": code,
-                    "label": (a.get("label") or code).strip(),
-                    "city": (a.get("city") or "").strip()
+                    "label": raw_label,
+                    "city": (a.get("city") or "").strip(),
+                    "country": m.group(1) if m else (a.get("country") or "")
                 })
                 seen.add(code)
 
@@ -253,6 +257,9 @@ def index():
             if r.status_code == 200:
                 data = r.json().get('data', [])[:10]
                 airport_index = _get_airport_index()
+                origin_info = airport_index.get(origin_code, {})
+                origin_country = origin_info.get('country', '')
+
                 for flight in data:
                     dest_code = flight.get('destination', 'N/A')
                     price = flight.get('value', 'N/A')
@@ -261,6 +268,7 @@ def index():
                     dest_info = airport_index.get(dest_code, {})
                     dest_label = _display_name(dest_info.get('label') or dest_code, dest_code) if dest_info else dest_code
                     dest_city = dest_info.get('city', '')
+                    dest_country = dest_info.get('country', '')
 
                     depart_str = datetime.strptime(departure_date, '%Y-%m-%d').strftime('%d%m')
                     if trip_type == 'roundtrip' and return_date:
@@ -275,6 +283,7 @@ def index():
                         'destination_code': dest_code,
                         'destination_label': dest_label,
                         'destination_city': dest_city,
+                        'destination_country': dest_country,
                         'price': price,
                         'num_stops': num_stops,
                         'booking_url': booking_url
@@ -282,10 +291,14 @@ def index():
         except Exception:
             pass
 
+    airport_index = _get_airport_index()
+    origin_country = airport_index.get(form_data.get('origin_code', ''), {}).get('country', '')
+
     return render_template(
         'index.html',
         flights=flights,
         origin_label=origin_label,
+        origin_country=origin_country,
         date=date,
         form_data=form_data
     )

--- a/templates/index.html
+++ b/templates/index.html
@@ -444,7 +444,7 @@
   <form method="POST" id="searchForm" class="p-4 form-container" autocomplete="off">
 
     <!-- Trip type toggle -->
-    <div class="d-flex mb-3">
+    <div class="d-flex flex-wrap gap-3 mb-3">
       <div class="trip-toggle btn-group" role="group">
         <input type="radio" class="btn-check" name="trip_type" id="trip_oneway" value="oneway"
                {% if form_data.trip_type != 'roundtrip' %}checked{% endif %}>
@@ -456,6 +456,15 @@
         <label class="btn" for="trip_roundtrip">
           <i class="fa fa-right-left me-1"></i> Round-trip
         </label>
+      </div>
+
+      <div class="trip-toggle btn-group" role="group" id="flightTypeToggle">
+        <input type="radio" class="btn-check" name="flight_type" id="ft_all" value="all" checked>
+        <label class="btn" for="ft_all">All</label>
+        <input type="radio" class="btn-check" name="flight_type" id="ft_domestic" value="domestic">
+        <label class="btn" for="ft_domestic"><i class="fa fa-house me-1"></i> Domestic</label>
+        <input type="radio" class="btn-check" name="flight_type" id="ft_international" value="international">
+        <label class="btn" for="ft_international"><i class="fa fa-earth-europe me-1"></i> International</label>
       </div>
     </div>
 
@@ -531,7 +540,7 @@
 
     <div id="flightsList">
       {% for flight in flights %}
-      <div class="flight-card" data-price="{{ flight.price }}">
+      <div class="flight-card" data-price="{{ flight.price }}" data-country="{{ flight.destination_country }}">
         <div class="flight-dest">
           <div class="flight-dest-top">
             <span class="flight-city">
@@ -740,6 +749,36 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('sortAsc').classList.toggle('active', order === 'asc');
     document.getElementById('sortDesc').classList.toggle('active', order === 'desc');
   };
+
+  // ── Flight type filter (domestic / international) ────
+  const ORIGIN_COUNTRY = {{ origin_country | tojson }};
+
+  function applyFlightTypeFilter() {
+    const selected = document.querySelector('input[name="flight_type"]:checked')?.value || 'all';
+    const container = document.getElementById('flightsList');
+    if (!container) return;
+    let visibleCount = 0;
+    container.querySelectorAll('.flight-card').forEach(card => {
+      const destCountry = card.dataset.country || '';
+      let show = true;
+      if (selected === 'domestic')      show = ORIGIN_COUNTRY && destCountry === ORIGIN_COUNTRY;
+      if (selected === 'international') show = !ORIGIN_COUNTRY || destCountry !== ORIGIN_COUNTRY;
+      card.style.display = show ? '' : 'none';
+      if (show) visibleCount++;
+    });
+    // update count label if present
+    const countEl = document.querySelector('.results-count strong');
+    if (countEl) countEl.textContent = visibleCount;
+  }
+
+  document.querySelectorAll('input[name="flight_type"]').forEach(r =>
+    r.addEventListener('change', applyFlightTypeFilter)
+  );
+  // hide toggle if no country data available
+  if (!ORIGIN_COUNTRY) {
+    const toggle = document.getElementById('flightTypeToggle');
+    if (toggle) toggle.style.display = 'none';
+  }
 });
 </script>
 


### PR DESCRIPTION
Parses country code from airport labels, passes origin_country to template, and adds a client-side toggle (All / Domestic / International) that filters results by comparing destination country to origin country. Toggle is hidden when country data is unavailable for the origin airport.

https://claude.ai/code/session_01DPwNUJWgHNpUpGdyH2suBd