### PR TITLE
Fix text color on secondary pages (blog, FAQ, terms, privacy, about)

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="container py-5 text-light">
+<div class="container py-5">
   <h1>About</h1>
   <p><strong>GetMeOutOfHere.Live</strong> is a simple flight finder built to show you the cheapest places you can fly to — no destination needed. Just choose your airport and dates, and we’ll bring you the lowest fares available.</p>
   <p>We partner with <strong>Travelpayouts</strong> to pull real-time flight prices from airlines and booking sites. When you book, we may earn a small commission — at no extra cost to you.</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,19 +25,17 @@
   <script src="{{ url_for('static', filename='fontawesome-free-6.7.2-web/js/all.js') }}"></script>
   <script defer data-domain="getmeoutofhere.live" src="https://plausible.io/js/script.js"></script>
   <style>
-    body{color:#eaf0ff;background: radial-gradient(1200px 600px at 80% -10%, rgba(130,255,210,0.12), transparent 60%),
-                      radial-gradient(1200px 600px at 10% 10%, rgba(110,168,255,0.14), transparent 60%),
-                      #0b1020;}
-    .top-nav a{ color:#9fb0ff; text-decoration:none; font-weight:600 }
-    .top-nav a:hover{ color:#cfe0ff; text-decoration:underline }
+    body{color:#1a1a2e;background:#f8f9fc;}
+    .top-nav a{ color:#2563eb; text-decoration:none; font-weight:600 }
+    .top-nav a:hover{ color:#1d4ed8; text-decoration:underline }
     .container-narrow{max-width:900px}
     footer{opacity:.85}
   </style>
 </head>
-<body class="background">
+<body>
   <nav class="container d-flex justify-content-between align-items-center py-3 top-nav">
     <div class="d-flex align-items-center gap-2">
-      <a href="{{ url_for('index') }}" class="fs-5 fw-bold text-decoration-none text-light">GetMeOutOfHere<span class="text-info">.Live</span></a>
+      <a href="{{ url_for('index') }}" class="fs-5 fw-bold text-decoration-none text-dark">GetMeOutOfHere<span class="text-primary">.Live</span></a>
       <i class="fa fa-plane ms-1" style="font-size:18px; opacity:.8"></i>
     </div>
     <div class="d-flex gap-3">
@@ -53,7 +51,7 @@
     {% block content %}{% endblock %}
   </main>
 
-  <footer class="container py-4 text-center text-secondary">
+  <footer class="container py-4 text-center" style="color:#6b7280;border-top:1px solid rgba(0,0,0,.08);margin-top:2rem">
     © {{ current_year if current_year else 2025 }} GetMeOutOfHere.Live
   </footer>
 

--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -10,33 +10,33 @@
 {% block content %}
 <style>
   .blog-hero { margin-bottom: 32px; }
-  .blog-hero h1 { font-size: 1.8rem; font-weight: 800; line-height: 1.2; margin-bottom: 10px; }
-  .blog-hero .subtitle { font-size: 1rem; color: #9fb0ff; margin-bottom: 14px; }
+  .blog-hero h1 { font-size: 1.8rem; font-weight: 800; line-height: 1.2; margin-bottom: 10px; color: #1a1a2e; }
+  .blog-hero .subtitle { font-size: 1rem; color: #6b7280; margin-bottom: 14px; }
   .blog-hero .airport-tag {
     display: inline-flex; align-items: center; gap: 6px;
-    background: rgba(110,168,255,.1); border: 1px solid rgba(110,168,255,.2);
+    background: rgba(37,99,235,.08); border: 1px solid rgba(37,99,235,.2);
     border-radius: 20px; padding: 5px 14px;
-    font-size: 0.78rem; color: #9fb0ff;
+    font-size: 0.78rem; color: #2563eb;
   }
 
   .blog-section { margin-bottom: 32px; }
   .blog-section h2 {
-    font-size: 1.1rem; font-weight: 700; color: #eaf0ff;
+    font-size: 1.1rem; font-weight: 700; color: #1a1a2e;
     margin-bottom: 14px; padding-bottom: 10px;
-    border-bottom: 1px solid rgba(255,255,255,.08);
+    border-bottom: 1px solid rgba(0,0,0,.1);
   }
   .blog-section p, .blog-section .body-text {
-    font-size: 0.92rem; color: #c0ccee; line-height: 1.75;
+    font-size: 0.92rem; color: #374151; line-height: 1.75;
   }
 
   .cta-box {
-    background: rgba(110,168,255,.08);
-    border: 1px solid rgba(110,168,255,.22);
+    background: rgba(37,99,235,.05);
+    border: 1px solid rgba(37,99,235,.18);
     border-radius: 16px; padding: 24px; margin: 36px 0;
     text-align: center;
   }
-  .cta-box h3 { font-size: 1.05rem; font-weight: 700; margin-bottom: 6px; }
-  .cta-box p { font-size: 0.85rem; color: #9fb0ff; margin-bottom: 16px; }
+  .cta-box h3 { font-size: 1.05rem; font-weight: 700; margin-bottom: 6px; color: #1a1a2e; }
+  .cta-box p { font-size: 0.85rem; color: #6b7280; margin-bottom: 16px; }
   .btn-cta {
     display: inline-block;
     background: linear-gradient(135deg, #3b7dd8 0%, #1a55b0 100%);
@@ -47,35 +47,35 @@
   .btn-cta:hover { opacity: .88; transform: translateY(-1px); color: #fff; }
 
   .disclaimer {
-    background: rgba(255,255,255,.03);
-    border: 1px solid rgba(255,255,255,.07);
+    background: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.08);
     border-radius: 12px; padding: 14px 16px;
-    font-size: 0.78rem; color: #5a6e9e; margin-bottom: 32px;
+    font-size: 0.78rem; color: #6b7280; margin-bottom: 32px;
     line-height: 1.55;
   }
-  .disclaimer i { color: #6ea8ff; margin-right: 5px; }
+  .disclaimer i { color: #2563eb; margin-right: 5px; }
 
   .related-section { margin-top: 36px; }
   .related-section h3 {
-    font-size: 0.75rem; font-weight: 700; color: #9fb0ff;
+    font-size: 0.75rem; font-weight: 700; color: #6b7280;
     text-transform: uppercase; letter-spacing: .07em; margin-bottom: 12px;
   }
   .related-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
   .related-card {
-    background: rgba(255,255,255,.04);
-    border: 1px solid rgba(255,255,255,.08);
+    background: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.1);
     border-radius: 12px; padding: 14px;
     text-decoration: none; display: block;
-    font-size: 0.82rem; font-weight: 600; color: #cfe0ff;
+    font-size: 0.82rem; font-weight: 600; color: #374151;
     transition: border-color .2s, background .2s;
     line-height: 1.35;
   }
   .related-card:hover {
-    background: rgba(255,255,255,.08);
-    border-color: rgba(110,168,255,.3);
-    color: #eaf0ff;
+    background: rgba(0,0,0,.06);
+    border-color: rgba(37,99,235,.3);
+    color: #1a1a2e;
   }
-  .related-card i { color: #6ea8ff; margin-bottom: 6px; display: block; font-size: 0.9rem; }
+  .related-card i { color: #2563eb; margin-bottom: 6px; display: block; font-size: 0.9rem; }
 
   @media (max-width: 576px) {
     .blog-hero h1 { font-size: 1.45rem; }
@@ -108,7 +108,7 @@
 
 <!-- CTA -->
 <div class="cta-box">
-  <h3><i class="fa fa-magnifying-glass me-2" style="color:#6ea8ff"></i>Search live prices now</h3>
+  <h3><i class="fa fa-magnifying-glass me-2" style="color:#2563eb"></i>Search live prices now</h3>
   <p>The prices above are typical ranges — actual fares change every day. Use our search tool for real-time prices from Aviasales.</p>
   <a href="{{ url_for('seo_airport', code=post.cta_airport) }}" class="btn-cta">
     Search cheap flights from {{ post.airport_names.split(',')[0] }} <i class="fa fa-arrow-right ms-2"></i>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="container py-5 text-light">
+<div class="container py-5">
   <h1>FAQ</h1>
   <h5>Do prices include taxes and fees?</h5>
   <p>Yes — the prices shown are estimates that usually include taxes. The final fare is confirmed on the booking site.</p>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="container py-5 text-light">
+<div class="container py-5">
   <h1>Privacy Policy</h1>
   <p>We respect your privacy. We don’t collect personal details unless you choose to share them (like subscribing to updates).</p>
   <p>We use simple analytics (like Plausible) to see how the site is used — but we don’t track you across the web or sell your data.</p>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="container py-5 text-light">
+<div class="container py-5">
   <h1>Terms of Use</h1>
   <p><strong>GetMeOutOfHere.Live</strong> is a free tool to help you find cheap flights.</p>
   <ul>


### PR DESCRIPTION
Switch base.html from dark navy theme to a clean light background (#f8f9fc) with dark text (#1a1a2e) so content is readable. Remove the photo background image class, update nav/footer link colors, and restyle blog_post.html to match the light theme. Remove Bootstrap text-light overrides from static pages.

https://claude.ai/code/session_01KGacbiiVbdMWUFH7bBW6AR