### PR TITLE
Filter live deals to this week's departures (next 7 days)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template, request, jsonify, send_from_directory, abort
-from datetime import datetime
+from datetime import datetime, timedelta
 from amadeus import Client
 import requests
 import os
@@ -799,13 +799,16 @@ def api_live_deals():
     airport_index = _get_airport_index()
     results = []
 
+    today = datetime.utcnow().date()
+    week_end = today + timedelta(days=7)
+
     for origin_code, origin_city in origins:
         try:
             params = {
                 'origin': origin_code,
                 'currency': currency_code,
                 'token': API_TOKEN,
-                'limit': 5,
+                'limit': 30,
                 'sorting': 'price',
             }
             r = requests.get(
@@ -814,18 +817,43 @@ def api_live_deals():
             )
             if r.status_code == 200:
                 data = r.json().get('data', [])
-                if data:
-                    best = min(data, key=lambda x: x.get('value', 9999))
-                    dest_code = best.get('destination', '')
-                    price = best.get('value', 0)
-                    if price and 5 < price < 2000:  # sanity bounds
-                        dest_info = airport_index.get(dest_code, {})
-                        dest_city = dest_info.get('city', '') or dest_code
-                        results.append({
-                            'route': f"{origin_city} \u2192 {dest_city}",
-                            'price': price,
-                            'symbol': currency_symbol,
-                        })
+                if not data:
+                    continue
+
+                # Filter to flights departing within the next 7 days
+                week_data = []
+                for f in data:
+                    raw = (f.get('depart_date') or '')[:10]
+                    if raw:
+                        try:
+                            d = datetime.strptime(raw, '%Y-%m-%d').date()
+                            if today <= d <= week_end:
+                                week_data.append(f)
+                        except ValueError:
+                            pass
+
+                if not week_data:
+                    continue  # no this-week deals for this origin
+
+                best = min(week_data, key=lambda x: x.get('value', 9999))
+                dest_code = best.get('destination', '')
+                price = best.get('value', 0)
+                if price and 5 < price < 2000:
+                    dest_info = airport_index.get(dest_code, {})
+                    dest_city = dest_info.get('city', '') or dest_code
+                    # Format departure date e.g. "Fri 14 Mar"
+                    raw_date = (best.get('depart_date') or '')[:10]
+                    try:
+                        dep_dt = datetime.strptime(raw_date, '%Y-%m-%d')
+                        date_label = dep_dt.strftime('%a ') + str(dep_dt.day) + dep_dt.strftime(' %b')
+                    except ValueError:
+                        date_label = ''
+                    results.append({
+                        'route': f"{origin_city} \u2192 {dest_city}",
+                        'price': price,
+                        'symbol': currency_symbol,
+                        'date': date_label,
+                    })
         except Exception:
             pass
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -485,7 +485,8 @@
       background: rgba(255,255,255,.09);
       border-color: rgba(110,168,255,.3);
     }
-    .deal-chip-route { color: #cfe0ff; font-size: 0.8rem; font-weight: 600; margin-bottom: 3px; }
+    .deal-chip-route { color: #cfe0ff; font-size: 0.8rem; font-weight: 600; margin-bottom: 2px; }
+    .deal-chip-date  { color: #5a6e9e; font-size: 0.7rem; margin-bottom: 3px; }
     .deal-chip-price { color: #82ffd2; font-size: 1rem; font-weight: 800; }
 
     /* ── GENERAL NEWSLETTER ────────────────────────── */
@@ -603,11 +604,11 @@
 {% if not seo_page %}
 <div class="live-feed-wrapper" id="liveFeedWrapper" style="display:none">
   <div class="live-feed-header">
-    <span class="pulse-dot"></span> Cheapest routes right now
+    <span class="pulse-dot"></span> This week's deals
   </div>
   <div class="live-feed-scroll" id="liveFeedScroll"></div>
   <div style="font-size:0.7rem; color:#5a6e9e; margin-top:6px; padding-left:2px;">
-    Live prices from Aviasales · updated hourly · one-way per person
+    Departing in the next 7 days · prices from Aviasales · one-way per person
   </div>
 </div>
 {% endif %}
@@ -867,8 +868,10 @@
           chip.href = '#searchForm';
           chip.style.textDecoration = 'none';
           const s = d.symbol || symbol || '£';
+          const dateStr = d.date ? `<div class="deal-chip-date">${d.date}</div>` : '';
           chip.innerHTML = `
             <div class="deal-chip-route">${d.route}</div>
+            ${dateStr}
             <div class="deal-chip-price">from ${s}${d.price}</div>
           `;
           scroll.appendChild(chip);


### PR DESCRIPTION
- Increase API limit to 30 results per origin so there's more to filter from
- Filter results to flights departing within the next 7 days using depart_date
- Skip origins with no this-week flights rather than showing stale/distant deals
- Include formatted departure date (e.g. "Fri 14 Mar") in each deal result
- Show date line in deal chips between route and price
- Update section header to "This week's deals" and subtitle to clarify "Departing in the next 7 days"

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp