### PR TITLE
Improve conversion: blog CTA, book button price, Aviasales trust

### DIFF
--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -150,10 +150,13 @@
 <!-- CTA -->
 <div class="cta-box">
   <h3><i class="fa fa-magnifying-glass me-2" style="color:#6ea8ff"></i>Search live prices now</h3>
-  <p>The prices above are typical ranges — actual fares change every day. Use our search tool for real-time prices from Aviasales.</p>
-  <a href="{{ url_for('index') }}" class="btn-cta">
+  <p>The prices above are typical ranges — actual fares change every day. Search below for real-time prices and book securely through Aviasales, one of Europe's largest flight search engines.</p>
+  <a href="{{ url_for('seo_airport', code=post.cta_airport) if post.cta_airport else url_for('index') }}" class="btn-cta">
     Search cheap flights{% if post.airport_names %} from {{ post.airport_names.split(',')[0] }}{% endif %} <i class="fa fa-arrow-right ms-2"></i>
   </a>
+  <p style="margin-top:10px; margin-bottom:0; font-size:0.78rem; color:rgba(234,240,255,0.45);">
+    <i class="fa fa-lock me-1"></i>Booking handled securely by Aviasales — trusted by 100M+ travellers
+  </p>
 </div>
 
 <!-- Email signup -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -790,8 +790,11 @@
           {% endif %}
 
           <a href="{{ flight.booking_url }}" target="_blank" rel="noopener" class="btn-book">
-            Book <i class="fa fa-arrow-right ms-1"></i>
+            Book for {{ form_data.currency_symbol or '£' }}{{ flight.price }} <i class="fa fa-arrow-right ms-1"></i>
           </a>
+          <div style="font-size:0.68rem; color:rgba(234,240,255,0.4); margin-top:4px; text-align:center;">
+            via Aviasales
+          </div>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
- Blog CTA now links to /cheap-flights-from/{cta_airport} instead of blank homepage — users land on a relevant pre-populated airport page
- Added trust line under blog CTA: "Booking handled securely by Aviasales — trusted by 100M+ travellers"
- Book button now shows price: "Book for £49 →" instead of just "Book"
- Added subtle "via Aviasales" label under each book button

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp