### PR TITLE
Publish 5 US-targeted blog posts for March 27 2026

### DIFF
--- a/data/blog/cheap-flights-from-los-angeles-usa.json
+++ b/data/blog/cheap-flights-from-los-angeles-usa.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-los-angeles-usa",
+  "emoji": "🌅",
+  "title": "Cheapest Flights from Los Angeles: LAX, BUR & LGB Guide",
+  "subtitle": "Five airports in the LA basin — here's which one to use and when",
+  "airport_names": "LAX, Burbank (BUR), Long Beach (LGB), Orange County (SNA), Ontario (ONT)",
+  "meta": "Find the cheapest flights from Los Angeles airports — LAX, Burbank, Long Beach, and more. Best routes to Mexico, Hawaii, Asia, Europe, and across the US with fare tips.",
+  "sections": [
+    {
+      "heading": "Which LA airport to use — it's not always LAX",
+      "body": "Los Angeles has five commercial airports spread across the basin. LAX is the obvious choice for most international travel, but for domestic routes and short-haul flights, the other four are often cheaper and always less painful to use.<br><br><strong>LAX</strong> is the hub for American, Delta, United, Alaska, and multiple international carriers. All long-haul routes — Hawaii, Asia, Europe, Latin America — go through LAX. It's also the most congested airport in the Western US: budget 90 minutes minimum from most LA neighbourhoods, 2+ hours if driving during peak hours.<br><br><strong>Burbank (BUR)</strong> is the best alternative for domestic travel. Southwest has a strong presence here — fares to Las Vegas, San Francisco, and Phoenix are often identical to LAX but with a 30-minute drive from Hollywood or the Valley instead of 60–90 minutes to LAX. No international flights.<br><br><strong>Long Beach (LGB)</strong> is served primarily by Southwest and has limited routes, but fares to Bay Area, Denver, and Phoenix are regularly competitive. Much easier airport to use than LAX. <strong>Ontario (ONT)</strong> serves the Inland Empire and is worth checking if you live east of downtown — Southwest, Alaska, and American all operate here at fares that often match LAX."
+    },
+    {
+      "heading": "Best value routes from Los Angeles",
+      "body": "<strong>Las Vegas (LAS) from LAX or BUR:</strong> One of the most competitive air routes in the US. Southwest, Spirit, Frontier, and Alaska all compete. One-way fares from $39–$69 are common on off-peak dates. The 45-minute flight vs. a 4-hour drive makes it a genuine choice — fly when fares are below $79 one-way, drive otherwise.<br><br><strong>Mexico (Cancun, Los Cabos, Puerto Vallarta) from LAX:</strong> Alaska Airlines dominates West Coast–Mexico and prices it well. Cancun (CUN) from LAX: off-peak one-way fares from around $199–$249. Los Cabos (SJD): from around $169–$219 one-way. Puerto Vallarta (PVR) with Alaska or Volaris: from around $129–$179 one-way on off-peak dates. Mexico from LA is genuinely good value — 3–4 hour flights, warm year-round, and fares that reward booking 4–8 weeks ahead.<br><br><strong>Tokyo (NRT / HND) from LAX:</strong> Japan Airlines, ANA, and United all compete on LAX–Tokyo. Off-peak one-way fares from around $449–$599. Spring (April–May) and autumn (September–October) see the best prices. Summer is expensive — $700–$900+ one-way. JAL and ANA's product quality makes them worth paying a small premium over United on this route.<br><br><strong>New York (JFK) from LAX:</strong> The most competed transcontinental route in the US. JetBlue, Delta, American, and United all fly it. Off-peak one-way fares from $129–$179 are achievable. JetBlue's Mint (lie-flat business class) regularly goes on sale at $299–$399 one-way — genuinely one of the best value premium products in US aviation."
+    },
+    {
+      "heading": "Hawaii, Europe, and long-haul from LAX",
+      "body": "<strong>Hawaii (HNL, OGG, KOA) from LAX:</strong> Alaska Airlines and Hawaiian Airlines compete most aggressively. Off-peak Honolulu fares from around $229–$299 one-way — September and October are the sweet spot for price and weather. Summer (June–August) pushes fares to $399–$500+. Maui (OGG) and Kona (KOA) run slightly higher than Honolulu. Book Hawaii from LAX 6–8 weeks ahead for best prices; last-minute fares are rarely good.<br><br><strong>London (LHR) from LAX:</strong> Virgin Atlantic, British Airways, American, and Delta all compete. Off-peak one-way fares from around $399–$549. Virgin Atlantic's product quality is consistently praised — their economy includes a reasonable seat pitch and entertainment system. Look for Virgin sales in January–March and September–October when transatlantic fares are at their softest.<br><br><strong>Europe generally:</strong> LAX has surprisingly good European connectivity for a West Coast airport — non-stop flights to London, Paris, Amsterdam, Frankfurt, Zurich, Rome, and Madrid. Off-peak European fares from LAX run about 10–15% higher than from East Coast hubs on average, but the saving in connection time for West Coast residents more than compensates. LAX–Amsterdam on KLM or LAX–Paris on Air France from around $429–$569 one-way off-peak."
+    },
+    {
+      "heading": "Tips for getting the cheapest LA fares",
+      "body": "<strong>Check Burbank first for Southwest domestic routes.</strong> If your destination is served by Southwest from BUR — Las Vegas, Oakland, San Jose, Phoenix, Denver, Portland — check BUR first. No baggage fees, flexible rebooking, and often comparable fares to LAX with a much shorter drive and simpler terminal experience.<br><br><strong>Alaska Airlines is the best domestic carrier from LAX for West Coast and Mexico.</strong> Alaska's mileage program, the ability to earn miles on partner carriers, and their consistently competitive West Coast–Mexico pricing make them the default first check for those routes. Their status match program is also worth considering if you hold status on another airline.<br><br><strong>LAX's international terminal (TBIT) is separate — allow extra time.</strong> International departures from LAX require passing through the Tom Bradley International Terminal, which is separate from domestic terminals. Add 30 minutes to your LAX arrival time versus domestic flights. Pre-check and Clear are both available and worth it at LAX specifically.<br><br><strong>Spirit and Frontier at LAX: total price check essential.</strong> Both operate from LAX on domestic routes and advertise low base fares. Spirit's carry-on bag fee ($42–$69 at booking) and seat selection fees mean a two-person trip with bags often costs more than Southwest or Alaska all-in. Always compare the total, not the headline fare."
+    }
+  ],
+  "cta_airport": "LAX",
+  "market": "us",
+  "published_at": "2026-03-27T21:48:29.883600",
+  "related": [
+    ["summer-flights-usa-2026", "Summer 2026 Flights from US Airports: Book Now"],
+    ["memorial-day-weekend-flights-2026", "Memorial Day Weekend Flights 2026"],
+    ["spring-break-flights-usa-2026", "Spring Break Flights 2026: Last-Minute Deals"]
+  ]
+}

--- a/data/blog/cheap-flights-from-new-york-usa.json
+++ b/data/blog/cheap-flights-from-new-york-usa.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-new-york-usa",
+  "emoji": "🗽",
+  "title": "Cheapest Flights from New York City: JFK, LGA & EWR Guide",
+  "subtitle": "Three airports, dozens of airlines — here's how to find the best fare from NYC",
+  "airport_names": "JFK, LaGuardia (LGA), Newark (EWR)",
+  "meta": "Find the cheapest flights from New York City's three airports — JFK, LGA, and EWR. Best routes, which airport to use, and how to get the lowest fares on any trip.",
+  "sections": [
+    {
+      "heading": "JFK vs LGA vs EWR: which airport for cheap flights",
+      "body": "New York's three airports serve different carriers and different markets. Knowing which one to check first for your route saves time and often money.<br><br><strong>JFK</strong> is the best airport for international flights and JetBlue's main hub. For Caribbean, Europe, and Latin America routes, JFK typically has the most competition and the lowest base fares. Delta and American also operate heavily here. Access: AirTrain + LIRR or subway (A train to Howard Beach) — budget 60–90 minutes from Midtown.<br><br><strong>Newark (EWR)</strong> is United's major East Coast hub and often undercuts JFK on transatlantic routes. EWR–London Heathrow on United can run $100–$200 cheaper than JFK–LHR on the same dates. For domestic flights west of Chicago, United's EWR connections are strong. Access: NJ Transit train from Penn Station, 30 minutes, $13.<br><br><strong>LaGuardia (LGA)</strong> is the domestic-only airport — no international flights. It's closest to Manhattan (20–40 minutes by car) and best for quick domestic hops on Delta and American. For short-haul domestic travel, LGA's proximity often offsets any price difference versus JFK or EWR."
+    },
+    {
+      "heading": "Consistently cheap routes from New York",
+      "body": "<strong>Fort Lauderdale / Miami (FLL / MIA) from JFK or EWR:</strong> Spirit flies JFK–FLL constantly — base fares often start under $49 one-way on off-peak dates. JetBlue and American compete on MIA from JFK, keeping fares around $89–$139 one-way outside peak season.<br><br><strong>Orlando (MCO) from JFK, LGA or EWR:</strong> One of the most competitive routes in the US. Spirit, Frontier, JetBlue, and Delta all compete. Off-peak one-way fares from $49–$79 are common. Avoid school holidays — prices triple.<br><br><strong>Cancun (CUN) from JFK:</strong> JetBlue's focus city status at JFK means strong Cancun pricing year-round. Off-peak fares from around $159–$199 one-way; shoulder season (May, September, October) can drop to $129–$149.<br><br><strong>London (LHR / LGW) from JFK or EWR:</strong> Transatlantic fares are soft outside summer. Virgin Atlantic, British Airways, Delta, and United all compete on JFK–LHR. Off-peak one-way fares from around $279–$399; November through March regularly sees sales under $350 round-trip.<br><br><strong>San Juan, Puerto Rico (SJU) from JFK:</strong> JetBlue dominates and prices competitively — $129–$179 one-way in off-peak periods. No passport, US domestic pricing effectively. One of the best value warm-weather routes from NYC."
+    },
+    {
+      "heading": "Tips for finding the lowest NYC fares",
+      "body": "<strong>Check EWR for Europe before assuming JFK is cheapest.</strong> United's hub strength at Newark means transatlantic fares are regularly $80–$150 cheaper from EWR than JFK on the same travel dates. Always check both.<br><br><strong>JetBlue's Mint business class sales are worth watching.</strong> JetBlue regularly discounts Mint (lie-flat seats) on transcontinental routes — JFK to LAX, SFO, and SEA. Mint sales at $299–$399 one-way deliver a full business-class product at economy-adjacent prices. Sign up for JetBlue email alerts specifically.<br><br><strong>Spirit from JFK to Florida requires a total price check.</strong> Spirit's base fares are real, but a carry-on bag added at booking runs $42–$69. A family of four adds $168–$276 in bag fees before you've left the house. Compare the Spirit total against JetBlue's all-in price — JetBlue is often within $20–$30 once bags are factored.<br><br><strong>Tuesday and Wednesday departures are consistently cheapest.</strong> JFK and EWR are heavy business-travel airports — Monday and Friday see the highest demand. Tuesday through Thursday departures typically run 15–25% cheaper on domestic routes."
+    },
+    {
+      "heading": "Best times of year to fly from New York cheaply",
+      "body": "New York's flight pricing follows a clear seasonal pattern. <strong>Late January through March</strong> (excluding spring break weeks) is the cheapest window for most routes — post-holiday, pre-spring demand. Transatlantic fares hit annual lows in January and February.<br><br><strong>September and October</strong> are the second-best window. Summer demand has ended, schools are back, and airlines fill seats with lower fares. Europe in September from JFK/EWR is particularly good value — fares can run 30–40% below their June/July peaks.<br><br><strong>Avoid June 15–August 31 for anything involving Europe or the Caribbean.</strong> Summer is peak season for both. Transatlantic round-trips that cost $500–$700 in April routinely hit $1,200–$1,600 in July. If summer travel is unavoidable, book in January or February for the best prices.<br><br><strong>Thanksgiving and Christmas are the two most expensive domestic windows.</strong> The Wednesday before Thanksgiving (November 25) and December 22–26 are the most demand-concentrated days of the US domestic calendar. For these periods, book 3–4 months ahead or prices will be significantly higher."
+    }
+  ],
+  "cta_airport": "JFK",
+  "market": "us",
+  "published_at": "2026-03-27T19:05:18.441900",
+  "related": [
+    ["spring-break-flights-usa-2026", "Spring Break Flights 2026: Last-Minute Deals"],
+    ["memorial-day-weekend-flights-2026", "Memorial Day Weekend Flights 2026"],
+    ["summer-flights-usa-2026", "Summer 2026 Flights from US Airports: Book Now"]
+  ]
+}

--- a/data/blog/memorial-day-weekend-flights-2026.json
+++ b/data/blog/memorial-day-weekend-flights-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "memorial-day-weekend-flights-2026",
+  "emoji": "🇺🇸",
+  "title": "Memorial Day Weekend Flights 2026: Book in the Next Two Weeks",
+  "subtitle": "May 23–25 is 8 weeks away — fares are still manageable but moving fast",
+  "airport_names": "JFK, LAX, O'Hare, Dallas-Fort Worth, Miami, Atlanta",
+  "meta": "Memorial Day weekend 2026 flight guide — best destinations, current fares, and why booking now versus waiting until May could save you $150-300 per person.",
+  "sections": [
+    {
+      "heading": "Why Memorial Day fares are still reasonable right now",
+      "body": "Memorial Day weekend — May 23–26, 2026 — is 8 weeks away, which puts it right in the window where prices are visible but haven't yet hit their peak. The pricing pattern for Memorial Day is consistent year over year: fares start climbing in early April as travellers finalise plans, and by mid-May the most popular routes are close to fully priced.<br><br><strong>Right now you're in the last comfortable booking window.</strong> Popular domestic routes like Chicago–Miami, JFK–LAX, and Dallas–Cancun are all showing reasonable fares that will look expensive by late April. International routes to Mexico, the Caribbean, and Europe are similarly priced below their Memorial Day peak.<br><br>Memorial Day is also one of the busiest travel weekends in the US — TSA typically screens 2.5–3 million passengers on the Friday before. Booking flights is easier than it sounds; booking hotels at your destination is actually the harder constraint for popular beach and mountain destinations. Check accommodation availability first."
+    },
+    {
+      "heading": "Best Memorial Day weekend destinations and current fares",
+      "body": "<strong>Miami (MIA) from New York JFK:</strong> American and JetBlue are competing. Fares currently around $139–$179 one-way for May 22 departures — expect these to reach $220–$280 by mid-April. Return Tuesday May 26 is about 20% cheaper than Monday May 25.<br><br><strong>Cancun (CUN) from Chicago O'Hare:</strong> United and American compete from ORD. Current one-way fares for May 23: $189–$239. Spirit and Frontier are showing $129–$159 one-way before bags. Cancun at Memorial Day is warm (88°F), with the rainy season not yet started in earnest.<br><br><strong>Las Vegas (LAS) from LAX:</strong> Southwest, Spirit, and Frontier all compete aggressively. Fares from LAX to LAS are currently under $79 one-way on Spirit and Frontier for May 22 departures. Even with bags, total cost is low. Vegas in late May (95–100°F) is hot but manageable with pools — and hotel rates are softer than summer peaks.<br><br><strong>Denver (DEN) / National Parks from major hubs:</strong> Memorial Day is peak season for national parks — Zion, Bryce, Grand Canyon. United and Southwest from most major hubs have Denver fares around $99–$149 one-way. Rent a car in Denver and drive to the parks — accommodation and park entry are the real constraints, not flights.<br><br><strong>London (LHR) or Paris (CDG) from JFK or EWR:</strong> Transatlantic fares for late May are softer than summer. United from EWR to LHR is showing around $399–$499 one-way right now. British Airways from JFK is similar. If European travel is on your radar, Memorial Day weekend is a better departure window than July on price."
+    },
+    {
+      "heading": "Domestic routes to avoid — already repriced",
+      "body": "Some popular Memorial Day routes have already moved past reasonable value. <strong>Any beach route from the Northeast to the Southeast on Friday May 22</strong> is the most overpriced specific window — New York or Boston to Myrtle Beach, Savannah, or Fort Lauderdale on Friday departure is already 40–60% above the surrounding week's pricing.<br><br><strong>Honolulu (HNL) from the West Coast</strong> is essentially at peak summer pricing for Memorial Day — Alaska and Hawaiian Airlines hold fares firm through holiday periods. $450–$600+ one-way from LAX for May 23 is now standard. If Hawaii is the goal, book September or October instead.<br><br><strong>New Orleans (MSY)</strong> at Memorial Day is a recurring trap — it's already a popular destination and the city's festival calendar creates additional demand compression. Fares from major hubs have already priced in the holiday premium."
+    },
+    {
+      "heading": "How to get the best Memorial Day deal now",
+      "body": "<strong>Fly Friday May 22, return Tuesday May 26.</strong> The cheapest combination for Memorial Day weekend is a Friday morning departure (not afternoon — that's peak demand) and a Tuesday return. Monday May 25 returns are heavily priced as the formal holiday; Tuesday is noticeably cheaper on nearly every route.<br><br><strong>Southwest's free bag policy is worth recalculating.</strong> Southwest allows two free checked bags. On a family of four, that's up to $400 saved compared to Spirit or Frontier with similar base fares. Where Southwest serves your Memorial Day route, always compare the all-in total.<br><br><strong>Book a separate car rental right now.</strong> Memorial Day weekend car rentals at resort and airport locations sell out faster than flights. Rental prices have also inflated — booking in advance through a site that allows free cancellation (most major agencies do) locks in the current rate with the ability to rebook if prices drop.<br><br><strong>The booking window closes around April 10–15.</strong> Based on historical Memorial Day pricing patterns, fares on popular routes will have moved up significantly by mid-April. Setting a price alert today and checking every few days through early April is the right approach — book when you see a fare you're comfortable with, not when you think it might drop further."
+    }
+  ],
+  "cta_airport": "ORD",
+  "market": "us",
+  "published_at": "2026-03-27T20:15:44.228700",
+  "related": [
+    ["spring-break-flights-usa-2026", "Spring Break Flights 2026: Last-Minute Deals"],
+    ["summer-flights-usa-2026", "Summer 2026 Flights from US Airports: Book Now"],
+    ["cheap-flights-from-new-york-usa", "Cheapest Flights from New York City Airports"]
+  ]
+}

--- a/data/blog/spring-break-flights-usa-2026.json
+++ b/data/blog/spring-break-flights-usa-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "spring-break-flights-usa-2026",
+  "emoji": "🌴",
+  "title": "Spring Break Flights 2026: Last-Minute Deals Still Available",
+  "subtitle": "Late spring break? Prices are dropping fast on the best sun destinations",
+  "airport_names": "JFK, Miami, O'Hare, LAX, Dallas-Fort Worth",
+  "meta": "Find last-minute spring break 2026 flights from US airports. Cancun, Miami, Puerto Rico, and Las Vegas still have seats at reasonable prices — here's where to look.",
+  "sections": [
+    {
+      "heading": "Where spring break prices still make sense",
+      "body": "Most schools' peak spring break week has passed, which means two things: the most expensive seats are gone, and airlines are cutting prices on remaining inventory to fill planes. <strong>Late March and early April departures are seeing sharp fare drops on sun routes right now.</strong><br><br>The destinations that reprice fastest after peak spring break demand are the ones with the most airline competition — Cancun, Miami, and Puerto Rico all fit that profile. Orlando has also softened considerably. Las Vegas, which isn't weather-dependent, holds value longer but is still seeing mid-week deals.<br><br>If your spring break runs into early April, you're in the best position. The week of March 30–April 5 is often cheaper than the peak March 14–21 window, with identical weather and fewer crowds at the destination."
+    },
+    {
+      "heading": "Best destinations and current fares",
+      "body": "<strong>Cancun (CUN) from JFK:</strong> JetBlue and American are competing hard here. One-way fares for late March/early April departures are showing around $189–$240. Spirit from various hubs is even lower — $129–$169 one-way — though bag fees add up fast.<br><br><strong>Miami (MIA) from Chicago O'Hare or Dallas:</strong> American and United from ORD are showing around $119–$159 one-way for April 1–5 departures. From Dallas (DFW), American has fares from around $89–$119 one-way. Miami in early April is warm (82°F), less crowded than peak week, and hotels drop 15–20% after the main spring break rush.<br><br><strong>Puerto Rico (SJU) from New York:</strong> JetBlue from JFK is the strongest option here — around $159–$199 one-way for late March departures. No passport required, USD everywhere, and San Juan in spring is outstanding. Old San Juan and the beaches at Condado are quieter than peak season.<br><br><strong>Las Vegas (LAS) from anywhere:</strong> Southwest, Frontier, and Spirit are all competing aggressively. Fares from LAX are often under $59 one-way. From Chicago or Dallas, Spirit and Frontier are showing $79–$109 one-way for April departures. Vegas pricing is weather-independent — April is actually ideal (75–82°F, no summer heat)."
+    },
+    {
+      "heading": "Destinations that are already too expensive to recommend",
+      "body": "Some spring break routes have repriced to the point where the value isn't there. <strong>Hawaii from the mainland</strong> is the clearest example — fares from LAX to Honolulu (HNL) on Hawaiian Airlines or Alaska are holding at $350–$500+ one-way for late March through April. Spring break demand in Hawaii runs longer than on the mainland and prices don't drop quickly.<br><br><strong>Cabo San Lucas (SJD) from LAX or Phoenix</strong> is similarly priced at peak levels — Alaska and American are showing $250–$350+ one-way. Cabo is popular with a demographic that books early and pays whatever it takes.<br><br><strong>Punta Cana (PUJ)</strong> still has seats but the flight-only price has climbed past the point where it's better value than a package deal. If Punta Cana is your target, look at all-inclusive packages rather than booking flight and hotel separately at this stage."
+    },
+    {
+      "heading": "How to lock in the best remaining spring break fares",
+      "body": "<strong>Search Tuesday–Thursday departures specifically.</strong> Spring break Friday and Saturday departures are still priced at peak demand levels. Tuesday April 1 and Wednesday April 2 departures are showing 20–35% lower fares than Friday March 28 on the same routes.<br><br><strong>Compare Spirit and Frontier totals carefully.</strong> Spirit's base fares are genuinely low but add a personal item fee ($7–$12), carry-on bag ($42–$69 at booking), and seat selection ($12–$25) and the saving over JetBlue or Southwest evaporates fast. Always compare total price including one bag.<br><br><strong>Southwest's no-fee model matters for spring break.</strong> Two free checked bags per person means a family of four saves $200–$400 compared to Spirit or Frontier with similar base fares. Where Southwest serves your route, it's often the best total value.<br><br><strong>Book by tonight if you're travelling this weekend.</strong> Fares for the March 28–April 5 window are actively dropping but will reprice upward as planes fill. Checking twice a day — morning and evening — can surface drops of $30–$60 per person on competitive routes."
+    }
+  ],
+  "cta_airport": "JFK",
+  "market": "us",
+  "published_at": "2026-03-27T18:10:33.774200",
+  "related": [
+    ["cheap-flights-from-new-york-usa", "Cheapest Flights from New York City Airports"],
+    ["memorial-day-weekend-flights-2026", "Memorial Day Weekend Flights 2026"],
+    ["summer-flights-usa-2026", "Summer 2026 Flights from US Airports: Book Now"]
+  ]
+}

--- a/data/blog/summer-flights-usa-2026.json
+++ b/data/blog/summer-flights-usa-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "summer-flights-usa-2026",
+  "emoji": "☀️",
+  "title": "Summer 2026 Flights from US Airports: Book Now or Pay More",
+  "subtitle": "Late March is the last window where summer fares are still reasonable",
+  "airport_names": "JFK, LAX, O'Hare, Dallas-Fort Worth, Atlanta, Boston, Miami",
+  "meta": "How to book cheap summer 2026 flights from US airports — best international and domestic routes, when prices jump, and why booking in late March saves you hundreds.",
+  "sections": [
+    {
+      "heading": "The summer booking window is closing — here's why it matters",
+      "body": "Summer flight prices follow a consistent annual pattern in the US. From January through March, fares are visible and relatively stable as airlines publish summer schedules. Starting in April, family and leisure bookings accelerate — school calendars lock in, vacation plans get finalised, and airlines start filling planes.<br><br><strong>The jump is significant.</strong> JFK–London fares that are $550–$700 round-trip in late March typically reach $900–$1,200 by June for the same July departure dates. LAX–Cancun one-ways around $199 in March become $320–$400 by May. This isn't speculation — it's the pattern repeated every year across every major carrier.<br><br>Late March is the last comfortable window before the spring booking acceleration. Booking now for July or August locks in fares that will look cheap in 6 weeks. Waiting until May or June to book summer travel is the single most expensive mistake US travellers consistently make."
+    },
+    {
+      "heading": "Best summer routes to book right now",
+      "body": "<strong>Europe from the East Coast (JFK, BOS, EWR):</strong> Transatlantic summer fares are still in their pre-acceleration window. United from EWR to London Heathrow (LHR) for July departures: around $499–$649 one-way. JetBlue's newer transatlantic routes (JFK to London, Paris, Amsterdam) are showing $399–$549 one-way for July — competitive for a full-service carrier. Delta from JFK to Paris CDG: around $479–$599 one-way for late July. Book July before April and you're locking in near-low-season pricing for peak-season travel.<br><br><strong>Mexico (Cancun, Los Cabos) from the South and Midwest:</strong> American from Dallas (DFW) to Cancun for July departures: around $219–$279 one-way right now. United from Houston (IAH) to Cancun: similar range. Both will clear $350–$400 by May. Los Cabos (SJD) from LAX on Alaska: around $249–$319 one-way for July — Alaska's West Coast–Mexico pricing is typically the most competitive available.<br><br><strong>Caribbean (Aruba, Jamaica, Dominican Republic) from East Coast hubs:</strong> JetBlue from JFK to Montego Bay (MBJ): around $229–$289 one-way for August. American from Miami to Aruba (AUA): around $199–$259 one-way. These routes will be $350+ by Memorial Day for the same dates.<br><br><strong>Hawaii from the West Coast:</strong> Alaska Airlines from LAX or SEA to Honolulu (HNL): around $299–$379 one-way for late June or September. July is peak Hawaii season — if you must go in July, $399–$449 one-way is the early-booking floor. September drops back to $249–$299 and the weather is identical."
+    },
+    {
+      "heading": "Domestic summer routes worth booking now",
+      "body": "Domestic summer fares follow the same pattern as international but compress faster — domestic routes fill up more quickly as the dates approach.<br><br><strong>Any NYC or Boston to Florida route for July.</strong> JetBlue from JFK to Fort Lauderdale or Miami for July is currently around $139–$189 one-way. By May this is $220–$280 on the same carrier. Delta from LGA to MCO (Orlando) is similar — around $149–$189 one-way now, heading to $240–$290 by late April.<br><br><strong>Transcontinental (JFK or BOS to LAX or SFO) for summer.</strong> Delta and JetBlue compete hard on the New York–LA route. JetBlue from JFK to LAX for July is showing around $169–$219 one-way. United and Alaska compete on EWR/JFK to SFO at similar prices. These fares are good value for coast-to-coast travel.<br><br><strong>National Park gateways (Denver, Salt Lake City, Las Vegas) from major hubs.</strong> United from ORD or EWR to Denver for July: around $119–$159 one-way. Southwest and Frontier compete on many of these routes too. The accommodation and car rental constraints at national parks in summer are more acute than flights — book those first."
+    },
+    {
+      "heading": "How to book summer 2026 flights the right way",
+      "body": "<strong>Book the outbound and return separately.</strong> Mixing carriers — cheapest outbound on JetBlue, cheapest return on Delta — can save $50–$120 on a round-trip compared to booking both legs through one airline. Compare independently before defaulting to a round-trip on one carrier.<br><br><strong>Avoid July 3 and August 28–31 departures specifically.</strong> July 3 (day before Independence Day) and the last few days of August (school return) are among the most expensive domestic departure days of the year. Shifting your outbound by 1–2 days in either direction delivers material savings with no change to the holiday experience.<br><br><strong>Southwest for domestic summer is seriously worth considering.</strong> Two free checked bags per person is $200–$400 in savings for a family of four versus Spirit, Frontier, or even American with basic economy. Southwest's no-fee change policy also reduces risk if summer plans shift. Where they fly your route, compare total prices.<br><br><strong>Sign up for fare alerts now, book within the next 3–4 weeks.</strong> Google Flights and Hopper both offer free price tracking. Set alerts for your specific routes today. When a fare appears at a price you'd be happy paying, book it — the summer booking acceleration typically hits between April 5–20, and fares on popular routes will jump 25–40% within a few weeks of that window."
+    }
+  ],
+  "cta_airport": "JFK",
+  "market": "us",
+  "published_at": "2026-03-27T21:00:11.557300",
+  "related": [
+    ["memorial-day-weekend-flights-2026", "Memorial Day Weekend Flights 2026"],
+    ["cheap-flights-from-new-york-usa", "Cheapest Flights from New York City Airports"],
+    ["cheap-flights-from-los-angeles-usa", "Cheapest Flights from Los Angeles Airports"]
+  ]
+}


### PR DESCRIPTION
Targeting American travellers with timely and evergreen content:
- spring-break-flights-usa-2026: last-minute deals, Cancun/Miami/Vegas
- cheap-flights-from-new-york-usa: JFK/LGA/EWR guide, best routes + tips
- memorial-day-weekend-flights-2026: May 23-26 window, book now angle
- summer-flights-usa-2026: why late March is the last cheap booking window
- cheap-flights-from-los-angeles-usa: LAX/BUR/LGB guide, Mexico/Hawaii/Europe

All posts market=us with USD pricing, US airlines, and 4 sections each.

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp