### PR TITLE
Fix Brevo integration — remove custom attributes causing API rejection

### DIFF
--- a/app.py
+++ b/app.py
@@ -1093,15 +1093,7 @@ def subscribe():
     brevo_api_key = os.environ.get('BREVO_API_KEY')
     if brevo_api_key:
         try:
-            payload = {
-                'email': email,
-                'attributes': {
-                    'AIRPORT_CODE': airport_code,
-                    'AIRPORT_NAME': airport_name,
-                    'SIGNED_UP_AT': datetime.utcnow().isoformat(),
-                },
-                'updateEnabled': True,
-            }
+            payload = {'email': email, 'updateEnabled': True}
             resp = requests.post(
                 'https://api.brevo.com/v3/contacts',
                 json=payload,
@@ -1109,6 +1101,8 @@ def subscribe():
                 timeout=8,
             )
             brevo_ok = resp.status_code in (201, 204)
+            if not brevo_ok:
+                print(f"[subscribe] Brevo {resp.status_code}: {resp.text}", file=__import__('sys').stderr)
         except Exception as exc:
             print(f"[subscribe] Brevo error: {exc}", file=__import__('sys').stderr)
 


### PR DESCRIPTION
Custom attributes (AIRPORT_CODE etc.) must be pre-defined in Brevo dashboard before use. Sending email only for now; add error logging to surface any future API failures.

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp