### PR TITLE
Re-enable airport attributes in Brevo contact payload

### DIFF
--- a/app.py
+++ b/app.py
@@ -1093,7 +1093,14 @@ def subscribe():
     brevo_api_key = os.environ.get('BREVO_API_KEY')
     if brevo_api_key:
         try:
-            payload = {'email': email, 'updateEnabled': True}
+            payload = {
+                'email': email,
+                'attributes': {
+                    'AIRPORT_CODE': airport_code,
+                    'AIRPORT_NAME': airport_name,
+                },
+                'updateEnabled': True,
+            }
             resp = requests.post(
                 'https://api.brevo.com/v3/contacts',
                 json=payload,


### PR DESCRIPTION
AIRPORT_CODE and AIRPORT_NAME now pre-defined in Brevo dashboard, safe to include in contact creation/update calls.

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp