### PR TITLE
Add 20 blog posts for UK and US markets (April 30 2026 batch)

### DIFF
--- a/data/blog/best-european-city-breaks-summer-2026.json
+++ b/data/blog/best-european-city-breaks-summer-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "best-european-city-breaks-summer-2026",
+  "emoji": "🏙️",
+  "title": "Best European City Breaks Summer 2026",
+  "subtitle": "Lisbon, Porto, Seville, Vienna, Krakow — cities that work in summer without the Barcelona price tag",
+  "airport_names": "Gatwick, Stansted, Manchester, Bristol, Edinburgh",
+  "meta": "Best European city breaks for summer 2026 from UK airports. Lisbon, Porto, Seville, Vienna, Krakow, Naples — cities with great flight value and better experiences than the obvious choices.",
+  "sections": [
+    {
+      "heading": "Why city breaks in summer 2026 are worth reconsidering",
+      "body": "The Mediterranean beach route is obvious in summer, but European city breaks in summer are worth a second look — particularly if you don't have school-age children constraining your dates. Cities don't price with the same cliff-edge urgency as beach resorts. Paris in July doesn't have the same demand compression as Ibiza in July. Some of the best-value European flights right now go to cities that are genuinely excellent in summer.<br><br>The cities worth considering fall into two groups. First, the <strong>Atlantic/Southern European cities</strong> that have genuine summer weather without the extreme heat problem — Porto, Seville in spring, Lisbon, Malaga city. Second, the <strong>Central and Eastern European cities</strong> that are overlooked in summer — Vienna, Prague, Krakow, Budapest — where budget carrier frequency keeps prices low and the heat is more manageable than coastal Turkey in August.<br><br>Budget: a four-night city break for two people, flights plus a central hotel, can be done for £400–600 total on the right routes this summer. That's about half what a week's beach holiday costs."
+    },
+    {
+      "heading": "Best value European city breaks right now",
+      "body": "<strong>Porto (OPO) from Stansted — Ryanair:</strong> Around £55–80 one-way for summer weekday departures. Porto is one of Europe's best cities and persistently underrated. The Ribeira waterfront, the wine cellars in Vila Nova de Gaia across the river, the trams — it's genuinely different from anywhere else in Europe. June and September are ideal; July and August are 28–30°C, slightly hotter than ideal for city walking.<br><br><strong>Krakow (KRK) from Stansted or Manchester:</strong> Ryanair from Stansted around £35–60 one-way for summer. Krakow is the best-value city break in Europe by most measures — excellent food, beautiful medieval old town, Auschwitz-Birkenau a 90-minute drive away for those who want to visit. Budget travellers can eat and drink extremely well on £40/day. Polish zloty means your pounds go far.<br><br><strong>Naples (NAP) from Gatwick or Stansted:</strong> easyJet from Gatwick around £75–100 one-way for June. Naples plus a day trip to Pompeii, a boat to Capri, or a hire car up the Amalfi Coast. The city itself is chaotic and brilliant — street food, pizza, and a historic centre that makes Rome look manicured. Not for travellers who need everything tidy.<br><br><strong>Vienna (VIE) from Gatwick or Stansted:</strong> easyJet from Gatwick around £65–90 one-way for summer. Vienna in June is ideal — 22–26°C, the outdoor Naschmarkt, the museums, Schönbrunn Palace. One of Europe's most functional cities for a long weekend. Flights are consistent because Vienna attracts enough business travellers to keep frequency high."
+    },
+    {
+      "heading": "Cities that used to be deals but aren't anymore",
+      "body": "Lisbon is the most notable case. Five years ago it was a bargain city break — £60 flights, €15 dinners, cheap accommodation. The tourism boom has repriced everything. Flights from Gatwick for July are now £90–120 one-way; a central hotel runs €150–200/night in summer. It's still a wonderful city but it's no longer cheap. If you haven't been, it's still worth it — just budget accordingly.<br><br>Barcelona is in the same category, pushed further by the tourist tax debate and the city's efforts to limit visitor numbers. July flights from Gatwick are £120–150 one-way and a central hotel is €180–250/night. Not a deal city break anymore.<br><br>Amsterdam has also re-priced. Flights are still reasonable at £50–75, but the hotel market in summer is fierce — central rooms easily reach €200/night in July. The city is excellent but expensive to stay in. The smarter approach for Amsterdam is May or October, not peak July."
+    },
+    {
+      "heading": "How to book European city breaks for summer",
+      "body": "<strong>Midweek departures and returns are materially cheaper.</strong> A Tuesday–Saturday trip to Krakow saves £20–40 per person versus Friday–Monday on Ryanair and easyJet. City breaks have more date flexibility than beach holidays — use it.<br><br><strong>Carry-on only unlocks the lowest fares.</strong> Ryanair and easyJet's cheapest fares are carry-on only. For a 4-night city break, two people can comfortably manage with two 10kg cabin bags. That unlocks fares that are £30–50 per person lower than the bag-included price. Pack light and book cheap.<br><br><strong>For central and eastern Europe, check Wizz Air too.</strong> Wizz Air flies from Luton, Gatwick, and Manchester to Budapest, Warsaw, Bucharest, Sofia, and several other eastern European cities at prices that often undercut Ryanair. They have a slightly higher bag fee structure — check carefully — but their base fares are often 20–30% below competitors.<br><br><strong>June and September are better than July and August for European cities.</strong> Not because of price — though June is 10–15% cheaper on most routes — but because heat. Walking Vienna, Naples, or Seville in 38°C August heat is unpleasant. The same cities at 24°C in June are genuinely enjoyable. If school holidays don't force your dates, go in June."
+    }
+  ],
+  "cta_airport": "STN",
+  "market": "uk",
+  "published_at": "2026-04-30T11:15:00.000000",
+  "related": [
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"],
+    ["cheap-flights-to-greece-from-uk-2026", "Cheap Flights to Greece from the UK 2026"],
+    ["spring-bank-holiday-flights-may-2026", "Spring Bank Holiday Flights May 2026"]
+  ]
+}

--- a/data/blog/cheap-caribbean-flights-summer-2026.json
+++ b/data/blog/cheap-caribbean-flights-summer-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-caribbean-flights-summer-2026",
+  "emoji": "🏝️",
+  "title": "Cheap Caribbean Flights Summer 2026",
+  "subtitle": "Jamaica, Dominican Republic, Aruba, Puerto Rico — what's still bookable at a reasonable price",
+  "airport_names": "New York JFK, Miami, Atlanta, Charlotte, Boston, Philadelphia",
+  "meta": "Find cheap Caribbean flights for summer 2026 from US airports. Jamaica, Dominican Republic, Aruba, Puerto Rico, the Bahamas — current fares, best routes, and what to avoid.",
+  "sections": [
+    {
+      "heading": "Caribbean in summer — what changes and what doesn't",
+      "body": "The Caribbean in summer is hurricane season. June through November is when tropical storms develop in the Atlantic and Gulf, with peak activity in August and September. That's important context because it affects both your travel experience and how airlines price tickets — knowing the weather risk is built into Caribbean summer fares, which are often lower than winter Caribbean fares precisely because demand drops with the hurricane season risk.<br><br>That doesn't mean summer Caribbean is a bad idea. <strong>The southern Caribbean — Aruba, Bonaire, Curaçao — sits outside the main hurricane belt and gets almost no storm activity.</strong> Puerto Rico, Jamaica, and the Dominican Republic are in the belt but see direct hurricane hits rarely — the risk is real but overstated for most years. The practical approach is to buy travel insurance with hurricane disruption cover, then book.<br><br>Current fares for summer Caribbean routes are reasonable — this is the sweet spot. Winter Caribbean is priced much higher because demand from cold-weather US cities is intense. Summer Caribbean fares reflect the reduced demand from weather risk. A June or September Caribbean trip from New York or Atlanta represents genuine value relative to February pricing."
+    },
+    {
+      "heading": "Best Caribbean routes and current fares",
+      "body": "<strong>New York (JFK) to Montego Bay, Jamaica (MBJ):</strong> JetBlue and American both fly this. JetBlue around $220–290 one-way for summer. JetBlue's service on this route is strong and they've invested in their Caribbean product. Montego Bay is the main resort hub; Negril (2 hours west) has the best beaches; Kingston is for culture not beaches. All-inclusive resorts near MBJ offer strong value.<br><br><strong>Miami (MIA) to Punta Cana, Dominican Republic (PUJ):</strong> American Airlines around $180–240 one-way for summer. The Dominican Republic's resort zone at Punta Cana is the Caribbean's largest concentration of all-inclusive hotels — every price point represented, all within 20 minutes of the airport. The beach at Bávaro is excellent. Book the flight and hotel package through American Vacations to compare against separate booking.<br><br><strong>New York (JFK) to Aruba (AUA):</strong> JetBlue and American. JetBlue around $240–310 one-way for summer. Aruba is the safe choice for summer Caribbean — it's geographically outside the hurricane belt (sits just above Venezuela), has near-zero rainfall, consistent trade winds, and 28°C water. One of the few Caribbean destinations where summer weather is as reliable as winter.<br><br><strong>Boston (BOS) or New York to San Juan, Puerto Rico (SJU):</strong> JetBlue and American both fly from both cities. JetBlue from JFK around $160–220 one-way for summer. Puerto Rico is US territory — no passport required for US citizens, no currency exchange, same laws. San Juan's Old City is one of the Caribbean's most interesting historic districts. El Yunque rainforest is 45 minutes east."
+    },
+    {
+      "heading": "Caribbean options that are already overpriced for summer",
+      "body": "The Turks and Caicos (PLS) has priced itself into luxury territory year-round. Summer fares from New York to Providenciales are $350–500 one-way, and the accommodation market starts at $400/night for anything near the beach. It's a genuinely beautiful destination but not a budget one. The Bahamas (Nassau NAS) is similar for most travellers — Nassau itself is unremarkable, and the good parts (Exumas, Harbour Island) require further connections and serious budget.<br><br>St. Barts, Anguilla, and Mustique are not accessible by any budget or mid-range framework — these are helicopter-and-yacht territory. Mention for completeness only: these islands exist, they have airports, they're not for this conversation.<br><br>Barbados in summer can work for UK travellers (direct Virgin and BA flights) but from the US it requires connections, which pushes the total price up significantly. Martinique and Guadeloupe are better served from Paris than from US cities."
+    },
+    {
+      "heading": "How to book summer Caribbean flights well",
+      "body": "<strong>All-inclusive packages are genuinely better value in the Caribbean than in Europe.</strong> Unlike Mediterranean all-inclusives (which can feel institutional), Caribbean all-inclusives at major properties in Jamaica, Punta Cana, and Aruba are genuinely good — good food, good drinks, beach access, multiple pools, entertainment. For a one-week family holiday, comparing a package price against a flight-plus-hotel-plus-meals budget almost always shows the all-inclusive winning.<br><br><strong>Book June and September over July and August.</strong> June 1–July 4 and September 15–30 are the sweet spots — outside peak school holiday demand, reduced hurricane risk relative to August, and 15–25% cheaper on flights and accommodation than peak summer. If school holidays don't constrain you, go in June or September.<br><br><strong>Travel insurance with hurricane cover is essential.</strong> A comprehensive policy that includes trip cancellation due to hurricane warnings costs $80–150 for a one-week trip. At peak hurricane season (August–September), it's a non-negotiable investment. Buy the policy at the point you book the flight — cover starts from booking date for cancellation purposes.<br><br><strong>Compare JetBlue and American carefully for Caribbean routes.</strong> JetBlue includes one free checked bag on most Caribbean fares (Even More Space excluded). American's Basic Economy is baggage-free. For a one-week trip with hold luggage, JetBlue's total cost is often lower than American's once you add American's bag fees. Run the full comparison before booking on headline fare alone."
+    }
+  ],
+  "cta_airport": "MIA",
+  "market": "us",
+  "published_at": "2026-04-30T13:15:00.000000",
+  "related": [
+    ["memorial-day-flights-book-now-2026", "Memorial Day Weekend Flights 2026"],
+    ["hawaii-vs-caribbean-flights-summer-2026", "Hawaii vs Caribbean Flights Summer 2026"],
+    ["cheap-flights-from-atlanta-2026", "Cheap Flights from Atlanta 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-from-atlanta-2026.json
+++ b/data/blog/cheap-flights-from-atlanta-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-atlanta-2026",
+  "emoji": "🍑",
+  "title": "Cheap Flights from Atlanta Hartsfield 2026",
+  "subtitle": "The world's busiest airport — and one of the best for finding cheap fares if you know where to look",
+  "airport_names": "Atlanta Hartsfield-Jackson",
+  "meta": "Cheap flights from Atlanta Hartsfield-Jackson (ATL) in 2026. Best domestic and international routes, Delta hub tips, and how to find fares that beat the headline price.",
+  "sections": [
+    {
+      "heading": "Atlanta's advantage: Delta's biggest hub",
+      "body": "Hartsfield-Jackson Atlanta is the world's busiest airport by passenger count and Delta Air Lines' primary hub. That combination means two things for Atlanta travellers: almost every domestic destination is reachable non-stop or with a single connection, and Delta's competitive positioning on ATL routes is fierce enough that fares are frequently lower than you'd expect from a hub airport.<br><br>The counterintuitive truth about hub airports: because airlines use them as connection points, there are more seats available on hub routes than thin point-to-point routes. More seats means more pricing tiers and more availability for the lower fare buckets. <strong>Atlanta to New York, Atlanta to LA, Atlanta to London — all these routes have abundant capacity, which keeps base fares under control.</strong><br><br>Where Atlanta struggles on price is on routes that Delta doesn't prioritise — specifically, routes where Southwest or Spirit compete from a different airport. Atlanta doesn't have a second major airport (Southwest flies into ATL but has fewer gates), so the discount carrier competition is thinner than in cities like Chicago or Dallas."
+    },
+    {
+      "heading": "Best routes from Atlanta and current fares",
+      "body": "<strong>Atlanta (ATL) to New York (JFK/LGA):</strong> Delta dominates with 20+ daily flights. Current summer fares: $130–170 one-way. The frequency means you're rarely paying a premium unless you need a specific time — there's always another flight two hours later. Perfect city for Delta Comfort+ upgrade pricing: usually $40–70 above economy for more legroom.<br><br><strong>Atlanta (ATL) to Miami (MIA):</strong> Delta and American both fly this. Current fares for summer: $120–160 one-way. The 2-hour flight to Miami is one of the most popular weekend trips from Atlanta. Spirit also flies ATL–MIA and FLL for $80–110 one-way — worth checking if you don't need bags and can tolerate Spirit's service model.<br><br><strong>Atlanta (ATL) to London (LHR) — Delta:</strong> Delta's direct service to Heathrow is consistent. Current summer return fares: $680–900 economy. Delta One (business) from ATL to LHR is frequently available for 80,000–120,000 SkyMiles on partner award space — one of the better Delta redemptions for those with miles accumulated.<br><br><strong>Atlanta (ATL) to Cancun (CUN):</strong> Delta and Aeromexico. Summer fares around $280–380 one-way. The 2.5-hour flight to Cancun from Atlanta makes Mexico beach vacations very accessible. Delta's partnership with Aeromexico means connecting options through Cancun to other Mexican cities are plentiful."
+    },
+    {
+      "heading": "Atlanta's underrated routes for summer 2026",
+      "body": "Atlanta has direct flights to destinations that Atlanta travellers consistently overlook in favour of obvious options. <strong>ATL to Montego Bay (MBJ), Jamaica</strong> is one of the best-value beach routes from the Southeast. Delta and JetBlue both fly it. Return fares for summer around $350–500. Jamaica's resort areas (Negril, Montego Bay, Ocho Rios) are within easy reach of MBJ and all-inclusive packages from ATL are strong value.<br><br><strong>ATL to Edinburgh (EDI)</strong> — Delta flies this nonstop in summer, which is rare for a regional UK airport from the US. Return fares around $700–900 for summer. Edinburgh in summer is excellent — the Fringe Festival is in August, the Highlands are an hour north. Fewer people book this than London or Dublin because they don't know the direct flight exists.<br><br><strong>ATL to San José, Costa Rica (SJO)</strong> is a 4-hour flight and frequently discounted. Delta and United both fly it. Return fares often fall to $380–480 for summer on sale. Costa Rica in summer is the rainy season on the Pacific side but dry on the Caribbean side — book accordingly."
+    },
+    {
+      "heading": "How to get the best fares from Atlanta in 2026",
+      "body": "<strong>Delta SkyMiles sweet spots from ATL.</strong> If you have SkyMiles, ATL is the best airport to redeem them from. Delta awards on ATL routes have the most availability and the most upgrade opportunities. The best redemption values are international business class and domestic first class upgrades — not economy awards, which have been devalued. SkyMiles Medallion status earns fastest on ATL metal flights if you're trying to qualify.<br><br><strong>Budget carriers from ATL.</strong> Spirit flies from Atlanta to Fort Lauderdale, Las Vegas, Orlando, New York, and a handful of other cities. Their base fares are $50–80 lower than Delta for summer, but the checked bag fee ($55–65 at booking) and carry-on fee ($55–65 at booking for full-size carry-ons) often wipe that out. Compare Spirit with bags to Delta without bags before deciding.<br><br><strong>MARTA from downtown Atlanta.</strong> MARTA's Gold Line runs directly from downtown to the airport in 20 minutes for $2.50. It's the most efficient way to reach ATL from Midtown, Buckhead, or downtown — significantly faster than driving in Atlanta traffic. The trains run until midnight, so late evening flights are feasible on MARTA.<br><br><strong>Book summer ATL departures before mid-May.</strong> Delta traditionally raises yields on summer ATL routes in late May as school holidays approach in Georgia (Georgia schools break up in late May). Fares for June, July, and August are all rising. The two weeks around Memorial Day are peak booking time — lock in your summer flights now."
+    }
+  ],
+  "cta_airport": "ATL",
+  "market": "us",
+  "published_at": "2026-04-30T12:30:00.000000",
+  "related": [
+    ["cheap-caribbean-flights-summer-2026", "Cheap Caribbean Flights Summer 2026"],
+    ["fourth-of-july-flights-2026", "Fourth of July Flights 2026"],
+    ["cheap-summer-flights-europe-from-us-2026", "Cheap Summer Flights to Europe from the US 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-from-birmingham-airport-2026.json
+++ b/data/blog/cheap-flights-from-birmingham-airport-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-birmingham-airport-2026",
+  "emoji": "✈️",
+  "title": "Cheap Flights from Birmingham Airport 2026",
+  "subtitle": "BHX routes that beat Gatwick and Stansted — and when to book them",
+  "airport_names": "Birmingham",
+  "meta": "Cheap flights from Birmingham Airport (BHX) in 2026. Best routes to Spain, Greece, Turkey, the Canaries and beyond — with fares that sometimes beat London airports.",
+  "sections": [
+    {
+      "heading": "Birmingham Airport's real advantage in 2026",
+      "body": "Birmingham sits at the centre of England's population. From BHX you can be through security in 15 minutes and at the gate in 20. There's no Gatwick Express, no Stansted Express, no hour-long tube ride. The airport serves 40+ summer destinations and on the right routes, fares are genuinely competitive with or cheaper than flying from London.<br><br>The key is knowing which routes BHX does well and which are better from Gatwick or Stansted. Jet2 is Birmingham's strongest carrier for leisure routes — they operate to Spain, Greece, Turkey, the Canaries, Egypt, and more from BHX with bags included and competitive pricing. Ryanair and easyJet both operate from BHX too, on a smaller network.<br><br><strong>For the West Midlands and wider Midlands catchment (Birmingham, Coventry, Worcester, Stoke, Leicester), driving to BHX and paying for parking often works out cheaper than rail to a London airport.</strong> Parking at Birmingham for a week runs £50–70. Rail to Gatwick from Birmingham can be £80–120 return per person. For a family of four, BHX is almost always the lower total cost."
+    },
+    {
+      "heading": "Best routes from Birmingham Airport and current fares",
+      "body": "<strong>Malaga (AGP) — Spain:</strong> Jet2 and easyJet both operate. Jet2 with bags for July departures currently around £120–150 one-way. easyJet without bags £95–120. Malaga is 3 hours — one of the most efficient routes from BHX. The Costa del Sol and Ronda are both within day-trip distance by car or train.<br><br><strong>Palma de Mallorca (PMI):</strong> Jet2 from Birmingham showing £115–145 one-way for July with bags. A good alternative to Manchester for Mallorca-bound West Midlanders. Similar pricing to Manchester Jet2 on this route, so departure time and convenience matter more than price difference.<br><br><strong>Heraklion, Crete (HER):</strong> Jet2 from Birmingham around £110–140 one-way for summer. Jet2 runs good frequencies to Crete from BHX — this is a strong option for East and West Midlands families who've been making the journey south to Gatwick unnecessarily.<br><br><strong>Antalya, Turkey (AYT):</strong> Jet2 from Birmingham showing £110–140 one-way for July with bags. Turkey from Birmingham is solid value — all-inclusive packages from BHX via Jet2 Holidays frequently come in £200–400 cheaper than equivalent Gatwick departures when you factor in the journey cost to London.<br><br><strong>Tenerife (TFS):</strong> Jet2 from Birmingham for winter/early spring and summer around £100–130 one-way with bags. Winter Tenerife departures from BHX are particularly good value — Jet2 runs the route year-round."
+    },
+    {
+      "heading": "Routes where Birmingham can't compete",
+      "body": "Some routes are simply thinner from BHX than from London. If you're going to Lisbon, Barcelona, Rome, or Amsterdam, London airports will have more flight options, lower minimum fares, and better timing. Ryanair flies Stansted–Barcelona 10 times daily; BHX gets one or two daily Ryanair flights on the same route. That frequency gap means lower floor prices at Stansted.<br><br>Long-haul from BHX is limited but growing. Emirates flies Dubai, Pakistan Airlines flies Islamabad, and a handful of US routes exist (mainly via connections). If you need transatlantic or Asian destinations, Birmingham's connecting options through Amsterdam (KLM), Dublin (Aer Lingus), or Doha (Qatar) are the practical route.<br><br>Short city-break routes to eastern Europe — Prague, Budapest, Krakow — are currently better priced from Stansted or Luton on Ryanair or Wizz Air. BHX doesn't have the budget carrier frequency on these to compete consistently."
+    },
+    {
+      "heading": "Birmingham Airport booking tips for summer 2026",
+      "body": "<strong>Check Jet2 first for package comparison.</strong> Birmingham is a strong Jet2 base and their all-inclusive packages from BHX to Turkey and Greece often represent the best total cost for a family holiday — flight, transfers, bags, and hotel in one price. Get a Jet2 Holidays quote before booking flight-only and finding out the hotel has been cleaned out.<br><br><strong>BHX parking booked now vs at the gate:</strong> Summer 2026 parking at Birmingham is already filling for peak July dates. Official BHX parking booked 8 weeks out costs £55–70 for a week. Left to the last month it reaches £100–130 for the same dates. Book parking when you book the flight.<br><br><strong>BHX vs East Midlands (EMA) for Nottingham/Leicester:</strong> East Midlands Airport is actually closer for some Midlands postcodes. EMA has strong Ryanair and Jet2 routes — check both airports before defaulting to Birmingham. For some routes (Faro, Lanzarote, Tenerife), EMA can undercut BHX by £15–30 per person on Jet2.<br><br><strong>Book summer from BHX before mid-May.</strong> Jet2 prices from Birmingham for peak July dates are still 20–25% below their ceiling. That ceiling hits when schools break up in July. The same seat that's £130 today will be £170+ by early June."
+    }
+  ],
+  "cta_airport": "BHX",
+  "market": "uk",
+  "published_at": "2026-04-30T10:45:00.000000",
+  "related": [
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK"],
+    ["cheapest-canary-islands-flights-uk-2026", "Cheapest Canary Islands Flights from UK 2026"],
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-from-boston-2026.json
+++ b/data/blog/cheap-flights-from-boston-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-boston-2026",
+  "emoji": "🦞",
+  "title": "Cheap Flights from Boston Logan 2026",
+  "subtitle": "BOS punches above its weight on transatlantic and Caribbean — here's how to use it",
+  "airport_names": "Boston Logan",
+  "meta": "Find cheap flights from Boston Logan Airport (BOS) in 2026. Best domestic and transatlantic routes, JetBlue and Delta fare tips, and when Logan beats New York on price.",
+  "sections": [
+    {
+      "heading": "Boston Logan's advantage over New York airports",
+      "body": "Boston Logan is a smaller, less chaotic airport than JFK, LaGuardia, or Newark — and for certain routes it's genuinely cheaper to fly from BOS than from New York. The main reason: Aer Lingus, Norwegian, and TAP Air Portugal all use Boston as a key transatlantic hub, and their competition with Delta, JetBlue, and American keeps transatlantic fares from BOS lower than you might expect for a non-hub city.<br><br>JetBlue has a major focus city at BOS and operates the highest frequency of any carrier on Boston's key domestic routes — JFK, Fort Lauderdale, Orlando, San Juan, and many others. <strong>JetBlue's BOS–FLL route is one of the most price-competitive domestic routes in the Northeast</strong> — Spirit and Frontier also compete, so the floor price is low year-round.<br><br>Logan itself is 10 minutes from downtown Boston by Silver Line bus (free from Terminal E on arrival) or Blue Line (from Airport station, a short shuttle ride). It's one of the easiest major US airports to access from a city centre — a meaningful advantage over JFK or Newark for city-centre travellers."
+    },
+    {
+      "heading": "Best routes from Boston and current fares",
+      "body": "<strong>Boston (BOS) to Fort Lauderdale (FLL):</strong> JetBlue, Spirit, and Frontier all compete. JetBlue around $110–145 one-way for summer. Spirit under $90 one-way without bags. Fort Lauderdale is effectively cheaper Miami — 30 minutes from South Beach, better cruise port, and a beach in its own right. Strong for families and budget travellers.<br><br><strong>Boston (BOS) to Dublin (DUB) — Aer Lingus:</strong> Aer Lingus's transatlantic operation is genuinely strong on this route. Current summer one-way fares: $390–520. Aer Lingus offers US Preclearance from Dublin — you clear US customs and immigration at Dublin Airport on departure, landing in the US as a domestic arrival. It's a significant time saving if you're transiting through Dublin on the return.<br><br><strong>Boston (BOS) to Reykjavik (KEF) — Icelandair:</strong> Icelandair operates BOS–KEF with competitive summer fares: $420–580 return. Iceland as a destination from Boston is excellent — 5.5 hours, extraordinary scenery, and the free stopover policy means you can see Iceland on the way to or from Europe at no extra fare cost.<br><br><strong>Boston (BOS) to San Juan, Puerto Rico (SJU):</strong> JetBlue around $160–210 one-way for summer. JetBlue is the dominant carrier on this route from BOS — frequency is high, fares are competitive, and the 3.5-hour flight is manageable. San Juan is popular with New England travellers for the warm weather, beaches, and no passport requirement for US citizens."
+    },
+    {
+      "heading": "Boston's domestic sweet spots",
+      "body": "Boston travellers sometimes overlook routes that save real money compared to New York pricing. <strong>BOS to Chicago (ORD)</strong> on American or JetBlue is often $30–50 cheaper than JFK–ORD because there are fewer business travellers on the route and less pricing pressure. JetBlue from BOS to Chicago Midway doesn't exist, but the BOS–ORD market has enough competition to keep prices honest.<br><br><strong>BOS to Miami (MIA)</strong> has American, JetBlue, and Frontier competing. Summer fares around $140–180 one-way. The BOS–MIA route is popular with snowbirds in reverse in summer — Miami residents flying to Boston to escape the heat — which keeps competition strong.<br><br><strong>BOS to Los Angeles (LAX)</strong> is around $220–300 one-way for summer on JetBlue or American. JetBlue's Mint (business class) on BOS–LAX is one of the best domestic business products in the US and sometimes available at $600–800 one-way — legitimately excellent value for a 5.5-hour transcontinental."
+    },
+    {
+      "heading": "Boston flight booking tips for summer 2026",
+      "body": "<strong>JetBlue TrueBlue points are disproportionately valuable from BOS.</strong> JetBlue has high frequency from Boston, which means award availability is better from BOS than from smaller JetBlue cities. If you have TrueBlue points, BOS-to-Caribbean and BOS-to-Florida redemptions are frequently available and the point costs are lower than transatlantic awards.<br><br><strong>Compare Aer Lingus to BA and Virgin for transatlantic.</strong> For Boston to London, Aer Lingus via Dublin (with US Preclearance at Dublin on the return) is frequently the best combination of price and convenience. BA flies BOS–LHR direct but often at $40–80 more per segment. Run the comparison on your specific dates — the Preclearance benefit alone is worth something.<br><br><strong>Fenway-area departures: drive vs cab vs T.</strong> Logan is deceptively accessible. The Silver Line from South Station connects to all Logan terminals. From Fenway, a $22 Uber to Logan is often the right call versus the T (20 minutes plus shuttle). From North End or Seaport, the Silver Line from Silver Line Way is walkable and free from Terminal E. Know your options before budgeting for transport.<br><br><strong>Book summer BOS departures before Memorial Day.</strong> JetBlue runs yield management from BOS very actively. The week after Memorial Day historically sees a fare jump on BOS transatlantic and Caribbean routes as demand crystallises for June–August. Book before May 25 for the best summer pricing."
+    }
+  ],
+  "cta_airport": "BOS",
+  "market": "us",
+  "published_at": "2026-04-30T13:30:00.000000",
+  "related": [
+    ["cheap-summer-flights-europe-from-us-2026", "Cheap Summer Flights to Europe from the US 2026"],
+    ["cheap-caribbean-flights-summer-2026", "Cheap Caribbean Flights Summer 2026"],
+    ["memorial-day-flights-book-now-2026", "Memorial Day Weekend Flights 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-from-chicago-ohare-2026.json
+++ b/data/blog/cheap-flights-from-chicago-ohare-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-chicago-ohare-2026",
+  "emoji": "🌬️",
+  "title": "Cheap Flights from Chicago O'Hare 2026",
+  "subtitle": "ORD is one of the world's most connected airports — here's how to get the most out of it",
+  "airport_names": "Chicago O'Hare",
+  "meta": "Find cheap flights from Chicago O'Hare (ORD) in 2026. Best domestic and international routes, current fares, and whether Midway (MDW) is ever cheaper for your destination.",
+  "sections": [
+    {
+      "heading": "Chicago O'Hare vs Midway — which airport to use",
+      "body": "Chicago has two major airports and the decision matters more than most people realise. O'Hare (ORD) is the United and American hub — massive, with the widest route network in the Midwest and connections to literally every US city and most international destinations. Midway (MDW) is the Southwest hub — smaller, less hectic, and often cheaper for domestic routes that Southwest flies.<br><br>The rule of thumb: <strong>if Southwest flies your route from Midway, compare Midway fares first.</strong> Southwest's two free bags, no change fees, and competitive base fares mean they frequently beat United and American's total cost from O'Hare on domestic routes. Chicago to Denver, Chicago to Fort Lauderdale, Chicago to Dallas — all routes where Southwest from Midway is worth checking against United from O'Hare.<br><br>For international and most long-haul domestic (west coast, Hawaii), O'Hare is the only practical choice. And for a handful of routes — Chicago to New York, Chicago to Boston, Chicago to DC — you have frequency so high at O'Hare that competition between United and American keeps prices sharp."
+    },
+    {
+      "heading": "Best value routes from Chicago O'Hare and current fares",
+      "body": "<strong>Chicago (ORD) to New York (JFK/LGA/EWR):</strong> United and American both fly this corridor constantly. Current fares for summer: around $130–180 one-way. The frequency is very high — 15–20 daily flights between O'Hare and the New York metro. That frequency means last-minute prices are less catastrophic than on thinner routes. But booking now for July is still meaningfully cheaper than booking in June.<br><br><strong>Chicago (ORD) to Miami (MIA):</strong> American hubs at both ORD and MIA, so they dominate this route. Current fares for summer: around $140–180 one-way. United also flies it. Miami over summer is hot and humid but the nightlife and beach infrastructure are fully operational. Book the Spirit or Frontier alternatives from Midway if you want to go cheaper.<br><br><strong>Chicago (ORD) to London (LHR):</strong> United and British Airways. Summer return fares currently around $720–950 economy. United's Polaris business class is a strong transatlantic product if you can find business fares at sale prices. Premium Economy on BA from ORD is often available at £600–800 above economy — worth comparing to the economy fare gap.<br><br><strong>Chicago (ORD) to Cancun (CUN):</strong> United, American, and Aeromexico all fly this. Summer fares around $250–350 one-way. The all-inclusive Cancun hotel market is strong from Chicago — United Vacations packages can be competitive for the Hotel Zone resorts."
+    },
+    {
+      "heading": "O'Hare's best-kept cheap routes",
+      "body": "A few O'Hare routes consistently underperform in awareness among Chicago travellers despite being excellent value. <strong>Chicago to Iceland (KEF) on Icelandair</strong> offers something the other transatlantic routes don't: a free layover in Iceland on the way to Europe. A Chicago–Reykjavik–Amsterdam itinerary with a 3-day Iceland stopover included can be found for $650–800 return. That's Europe plus Iceland for the price of Europe alone.<br><br><strong>Chicago to Bogotá (BOG) on Avianca</strong> is regularly underpriced. Colombia has become a major destination for American travellers and Avianca runs direct flights from ORD. Current summer fares around $380–480 return. Cartagena and Medellín are both excellent — book separately or via Bogotá.<br><br><strong>Chicago to Guadalajara (GDL) and Mexico City (MEX)</strong> are frequently undercut by Aeromexico and VivaAerobus. GDL serves the Los Altos/Tequila region and Guadalajara itself is one of Mexico's best cities for food. Fares often drop to $180–240 return on these routes when Aeromexico runs sales."
+    },
+    {
+      "heading": "O'Hare booking tips for summer 2026",
+      "body": "<strong>United MileagePlus sweet spots from ORD.</strong> O'Hare is United's biggest hub, which means award availability on United-metal flights from ORD is higher than from most US airports. If you have miles, check award space on ORD routes first — saver awards to Europe and South America are more frequently available from ORD than from secondary hubs.<br><br><strong>O'Hare's Terminal 1 (United) vs Terminal 3 (American).</strong> Both are good airports for connections. United's Terminal 1 is slightly easier to navigate for international connections; American's Terminal 3 has been recently renovated. If you're choosing a connecting itinerary, the terminal difference isn't a reason to prefer one carrier over the other.<br><br><strong>O'Hare express train from downtown.</strong> The Blue Line El train runs 24 hours directly between downtown Chicago (Clark/Lake or O'Hare) and the airport. It costs $5 and takes 45 minutes from downtown — significantly cheaper than Uber ($35–55 depending on traffic) and more reliable during rush hour. Worth knowing if you're flying from central Chicago.<br><br><strong>Book summer from ORD before mid-May.</strong> United and American both run seasonal pricing adjustments in late May when summer demand crystallises. Fares for July and August from O'Hare to popular leisure destinations (Miami, Denver, Las Vegas, Cancun, London) are all rising. Book within the next two weeks to capture current pricing."
+    }
+  ],
+  "cta_airport": "ORD",
+  "market": "us",
+  "published_at": "2026-04-30T12:15:00.000000",
+  "related": [
+    ["fourth-of-july-flights-2026", "Fourth of July Flights 2026"],
+    ["memorial-day-flights-book-now-2026", "Memorial Day Weekend Flights 2026"],
+    ["cheap-summer-flights-europe-from-us-2026", "Cheap Summer Flights to Europe from the US 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-from-dallas-fort-worth-2026.json
+++ b/data/blog/cheap-flights-from-dallas-fort-worth-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-from-dallas-fort-worth-2026",
+  "emoji": "🤠",
+  "title": "Cheap Flights from Dallas Fort Worth 2026",
+  "subtitle": "DFW is American Airlines' biggest hub — here's how to get better fares out of it",
+  "airport_names": "Dallas Fort Worth, Dallas Love Field",
+  "meta": "Find cheap flights from Dallas Fort Worth (DFW) and Dallas Love Field (DAL) in 2026. Best routes, current summer fares, and when Southwest at Love Field beats American at DFW.",
+  "sections": [
+    {
+      "heading": "DFW vs Love Field — the Dallas airport decision",
+      "body": "Dallas has two airports and unlike Chicago or New York, the split is clean: American Airlines at DFW for everything, Southwest Airlines at Love Field for domestic routes. The decision is essentially a carrier decision. If Southwest flies your route from Love Field, compare it seriously. If you need international connections or a carrier other than Southwest for domestic, DFW is the answer.<br><br>Love Field (DAL) is 10 minutes from downtown Dallas by Uber — a $15–20 ride. DFW is 25–35 minutes from downtown, $35–45 by Uber, or the DART Orange Line for $3. The proximity advantage of Love Field is real for downtown Dallas travellers. For suburbs to the north (Plano, Frisco, Allen), DFW is equally close or closer.<br><br><strong>Southwest's two free checked bags from Love Field are a tangible cost saving for most leisure travellers.</strong> A family of four checking bags saves $200–320 round-trip versus Spirit or Frontier at DFW. Even against American at DFW, where Basic Economy includes no bags, the Southwest total price is frequently competitive or lower despite a higher headline fare."
+    },
+    {
+      "heading": "Best routes from Dallas and current fares",
+      "body": "<strong>Dallas (DFW) to New York (JFK/LGA/EWR):</strong> American dominates. Current summer fares: $160–210 one-way. The 3-hour 30-minute flight is one of American's busiest routes. Late evening departures on American are frequently the cheapest — the 9–10pm flights often have lower base fares than the popular morning departures.<br><br><strong>Dallas (DAL/DFW) to Denver (DEN):</strong> Southwest from Love Field around $120–155 one-way for summer. United and American from DFW around $130–160. Denver from Dallas is a strong summer destination — the mountains are 45 minutes west of downtown Denver, and Colorado in summer is consistently one of the best domestic vacation states. The price gap between Southwest and the network carriers is small on this route.<br><br><strong>Dallas (DFW) to Cancun (CUN):</strong> American, United, and Aeromexico. Summer fares: $240–320 one-way. Cancun from Dallas is popular and well-served — multiple daily flights, strong all-inclusive packages via American Vacations. The 2.5-hour flight makes it a practical long-weekend destination as well as a week-long vacation.<br><br><strong>Dallas (DFW) to London (LHR):</strong> American Airlines direct. Summer return fares: $680–880 economy. American's flagship business class from DFW to LHR is a strong transatlantic product if you can find award availability or a business fare sale."
+    },
+    {
+      "heading": "Underrated routes from Dallas Fort Worth",
+      "body": "<strong>DFW to Reykjavik (KEF) on Icelandair.</strong> Icelandair added DFW–KEF direct in recent years. Summer return fares around $550–750. Iceland as a destination is extraordinary — geysers, waterfalls, the Golden Circle, northern lights in autumn — and the Icelandair stopover policy (free multi-day layover in Iceland en route to Europe) makes it uniquely flexible.<br><br><strong>DFW to Medellín, Colombia (MDE)</strong> has become a growing route with Avianca and American offering connections. Return fares around $350–480. Medellín has undergone one of the most remarkable urban transformations in Latin America and is now a thriving destination for food, culture, and cost-conscious travellers. Stay in El Poblado for safety and convenience.<br><br><strong>DFW to Panama City, Panama (PTY)</strong> is consistently underpriced. Copa Airlines flies this regularly. Return fares around $380–500. Panama City itself is excellent (canal, historic Casco Viejo, world-class seafood) and Panama as a connecting hub gives you access to South America at low add-on cost."
+    },
+    {
+      "heading": "Dallas flight booking tips for summer 2026",
+      "body": "<strong>Morning departure, same-day return for weekend trips.</strong> If you're doing a long weekend from Dallas — Denver Friday to Monday, New York Thursday to Sunday — book the 6–7am outbound and the 8–9pm return. Those are the efficiency brackets where airlines are filling seats people don't want, and the fares reflect that. Midday and late afternoon flights on weekend trips carry a premium.<br><br><strong>American AAdvantage program from DFW.</strong> DFW is American's biggest hub and award availability on American-metal flights out of DFW is generally better than anywhere else in the network. If you have AAdvantage miles and are planning a domestic trip, check DFW availability before assuming the miles aren't useful.<br><br><strong>Spirit and Frontier at DFW for Florida routes.</strong> Spirit and Frontier both operate from DFW to Orlando, Fort Lauderdale, and Tampa at significantly lower headline fares than American or United. If Florida is the destination and you're travelling carry-on only, Spirit from DFW to MCO at $85–110 one-way is genuinely hard to beat. Just know what you're getting — no frills, extra fees for everything else.<br><br><strong>Book summer DFW departures before Memorial Day.</strong> American raises yields on DFW summer routes in the two weeks around Memorial Day. Every year, the window between April and late May is the best time to buy summer American flights from Texas. The same July 4 flight that's $185 today will be $260 in June."
+    }
+  ],
+  "cta_airport": "DFW",
+  "market": "us",
+  "published_at": "2026-04-30T12:45:00.000000",
+  "related": [
+    ["fourth-of-july-flights-2026", "Fourth of July Flights 2026"],
+    ["cheap-caribbean-flights-summer-2026", "Cheap Caribbean Flights Summer 2026"],
+    ["cheap-summer-flights-europe-from-us-2026", "Cheap Summer Flights to Europe from the US 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-to-greece-from-uk-2026.json
+++ b/data/blog/cheap-flights-to-greece-from-uk-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-to-greece-from-uk-2026",
+  "emoji": "🇬🇷",
+  "title": "Cheap Flights to Greece from the UK 2026",
+  "subtitle": "Which Greek island to fly to, which airport to use, and when to book",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol, Edinburgh",
+  "meta": "Find cheap flights to Greece from UK airports in 2026. Crete, Rhodes, Corfu, Kos, Santorini, Athens — which routes offer the best value and when to book for summer.",
+  "sections": [
+    {
+      "heading": "Which Greek destination is actually cheapest from the UK",
+      "body": "Greece has seven main airports that UK carriers serve regularly, and prices vary considerably between them. The cheapest routes are almost never Santorini or Mykonos — those are served by full-service carriers at premium prices and stay expensive year-round. The best value is on the larger islands with multiple UK carriers competing: Crete, Rhodes, Corfu, and Kos.<br><br><strong>Crete (Heraklion, HER)</strong> is the most competitive in terms of airline choice — easyJet flies from Gatwick, Ryanair from Stansted, Jet2 from Manchester and Birmingham. That competition keeps prices lower than you'd expect for a 3.5-hour flight. Current early-summer fares for June departures are around £70–100 one-way from Gatwick.<br><br><strong>Rhodes (RHO)</strong> is the second-best value — Jet2 dominates from northern UK airports and prices competitively. easyJet and TUI also fly from Gatwick. Current fares for late June: around £75–105 one-way. The island has excellent beaches and a genuinely impressive medieval old town in Rhodes City."
+    },
+    {
+      "heading": "Island by island: current fares and what you get",
+      "body": "<strong>Crete (HER / CHQ) from Gatwick or Manchester:</strong> easyJet from Gatwick and Ryanair from Stansted both compete. June fares around £70–100 one-way. Crete is the biggest Greek island — you need a car to explore properly, but the variety is exceptional. Chania in western Crete is arguably the most beautiful town in Greece. Book early for July and August; peak prices reach £150–200 one-way.<br><br><strong>Rhodes (RHO) from Manchester or Gatwick:</strong> Jet2 from Manchester around £80–110 one-way for early June with bags included. easyJet from Gatwick similar. Rhodes old town is a UNESCO World Heritage site. The east coast beaches are consistently excellent. Good choice for a first Greek island trip.<br><br><strong>Corfu (CFU) from Birmingham or Manchester:</strong> Jet2 from Birmingham and Manchester, Ryanair from Stansted. June fares around £65–95 one-way. Corfu has a Venetian old town and lush interior that sets it apart from the more barren Aegean islands. Good for combining beach and culture.<br><br><strong>Kos (KGS) from Gatwick or Manchester:</strong> easyJet from Gatwick, Jet2 from Manchester. Around £70–100 one-way for June. Kos is popular with younger travellers; the main town is lively, the beaches are good, and it's one of the closest Greek islands to Turkey (visible from the beach). Avoid peak July/August if crowds aren't your thing."
+    },
+    {
+      "heading": "Athens, Santorini, and Mykonos — the honest picture",
+      "body": "Athens (ATH) is served by British Airways, easyJet and Aegean from Gatwick. Fares from around £90–120 one-way for summer — more expensive than the islands but the city itself is free of the island markup once you're there. The Acropolis, museums, and neighbourhood restaurants make Athens a strong choice for a city break rather than a beach holiday.<br><br>Santorini (JTR) is beautiful and expensive. There are no direct budget carrier flights from the UK — you're looking at British Airways or Aegean, often with a connection through Athens. Summer fares easily reach £250–350 one-way. The island is tiny and heavily visited; accommodation is among the most expensive in Greece. If the photos are what you're after, the reality is similar — just smaller and more crowded than you'd expect.<br><br>Mykonos (JMK) is even worse value for UK travellers — no direct budget flights, full-service fares at £200–300+ one-way, and then accommodation starting at €200/night for anything decent in summer. Both Santorini and Mykonos are experiences, not budget destinations."
+    },
+    {
+      "heading": "When to book and how to get the best prices",
+      "body": "<strong>Book June or September, not July/August.</strong> Greece in June (24–28°C) and September (24–27°C) is marginally cooler than July/August, genuinely less crowded, and 20–35% cheaper on flights and accommodation. The sea temperature in September is actually warmer than June. Unless school holidays force your hand, June and September are the obvious choices.<br><br><strong>Jet2 vs easyJet comparison for families.</strong> Jet2 includes 22kg checked baggage per person and seat selection — for a family of four, that's potentially £200–350 saved in bag fees versus Ryanair or easyJet on a one-week holiday. Where Jet2 flies your route (mainly northern UK airports), they're frequently the better total-cost option.<br><br><strong>Flying from Birmingham or Bristol can be cheaper than London.</strong> BHX and BRS have fewer connections but occasionally see Jet2 and Ryanair fares that undercut London airports on the same dates. Always check your regional airport before assuming Gatwick or Stansted is cheapest.<br><br><strong>Book summer Greece before mid-May.</strong> Summer Greek island fares accelerate sharply as schools approach their end-of-term dates. Anything leaving after July 19 will be noticeably cheaper if booked before May 15 versus after. If you're going in school holidays, book within the next two weeks."
+    }
+  ],
+  "cta_airport": "LGW",
+  "market": "uk",
+  "published_at": "2026-04-30T09:15:07.771200",
+  "related": [
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"],
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK"],
+    ["cheapest-canary-islands-flights-uk-2026", "Cheapest Canary Islands Flights from UK 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-to-spain-from-uk-2026.json
+++ b/data/blog/cheap-flights-to-spain-from-uk-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-to-spain-from-uk-2026",
+  "emoji": "🇪🇸",
+  "title": "Cheap Flights to Spain from the UK 2026",
+  "subtitle": "Malaga, Alicante, Barcelona, Seville — where the deals still are and where they aren't",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol, Edinburgh, Liverpool",
+  "meta": "Find cheap flights to Spain from UK airports in 2026. Malaga, Alicante, Barcelona, Seville, Palma — current fares, best routes, and when to book before prices spike.",
+  "sections": [
+    {
+      "heading": "Spain from the UK in 2026 — where the value is",
+      "body": "Spain is the UK's most flown-to holiday destination and has been for decades. The volume of seats means you can almost always find something reasonable — but 'reasonable' shifts dramatically depending on the route, the carrier, and when you're booking. April 30, right now, is still an acceptable window to book summer Spain. By late May, Malaga, Alicante, and Palma will be at or close to their annual pricing ceiling.<br><br>The routes that hold value longest are the ones with the most carrier competition. <strong>Malaga (AGP) is served from most UK airports by at least three carriers — Ryanair, easyJet, Jet2, and often TUI.</strong> That competition means Malaga prices stay more reasonable than Ibiza or Mallorca, where demand is sticky regardless of price. Faro is better still — Portugal doesn't carry the Spanish peak premium.<br><br>Current fares for July: Gatwick to Malaga on easyJet around £105–130 one-way. Manchester to Malaga on Jet2 with bags around £130–155. Not cheap by pre-2022 standards but reasonable for school-holiday dates. The question isn't whether to book — it's whether you book this week or pay more in June."
+    },
+    {
+      "heading": "Route by route — current fares from UK airports",
+      "body": "<strong>Malaga (AGP) from Gatwick or Manchester:</strong> easyJet from Gatwick around £105–130 one-way for July without bags. Jet2 from Manchester around £130–155 one-way with bags. The Costa del Sol is dense with package hotels and independent accommodation — flexible enough for any travel style. Ronda, two hours inland, is one of Spain's most impressive towns and accessible on a day trip.<br><br><strong>Alicante (ALC) from Gatwick, Manchester, or Edinburgh:</strong> easyJet from Gatwick around £90–115 one-way for July. Ryanair from Stansted £80–105. Alicante is the gateway to Benidorm, the Costa Blanca, and the Murcia region. Often 10–20% cheaper than Malaga on equivalent dates because the airport is further inland and less of a city destination in its own right.<br><br><strong>Barcelona (BCN) from Gatwick or Stansted:</strong> Vueling and easyJet from Gatwick around £115–145 one-way for July. Ryanair from Stansted to Girona (GRO, 90 minutes from Barcelona) around £60–85. If budget is the priority, Girona is the play — just factor in the bus transfer and time. Barcelona is genuinely excellent but it's not beach Spain; it's a city trip.<br><br><strong>Seville (SVQ) from Stansted:</strong> Ryanair around £65–90 one-way for summer. Seville in July is 37–40°C — genuinely hot. Go in May or early October instead. But the pricing is strong for budget-focused travellers who understand what they're booking into."
+    },
+    {
+      "heading": "Where the Spain deal has already gone",
+      "body": "Ibiza is priced at near-ceiling already. easyJet from Gatwick for late July is £160–200 one-way. If Ibiza is the plan, you should have booked in January or February — the demand for Ibiza flights is inelastic enough that airlines don't need to discount. The remaining seats will go to people who'll pay whatever it costs.<br><br>Palma de Mallorca (PMI) from any UK airport is similar — Jet2 from Manchester showing £140–175 one-way with bags for peak July. Not disastrous for a school holiday, but not a deal. Menorca (MAH) from the same airports is £80–100 one-way — significantly cheaper, quieter beaches, and frankly a better island for families who aren't on a clubbing trip.<br><br>Barcelona for school holidays is high. The city doesn't need to discount to fill seats in July. If you haven't booked yet and Barcelona is the target, consider Barcelona alternatives: Valencia is 90% of the experience at 60% of the price, and Ryanair flies it from Stansted for £65–85 one-way in July."
+    },
+    {
+      "heading": "How to book Spain cheaply in 2026",
+      "body": "<strong>Compare Jet2 total cost vs Ryanair/easyJet total cost.</strong> Ryanair's £60 fare to Alicante becomes £130+ once you add a 20kg hold bag (£30 each way) and an allocated seat (£10 each way). Jet2's £120 fare includes 22kg per person. For a family of four with luggage, Jet2's total cost is often lower than the budget carrier headline fare.<br><br><strong>Flying Friday to Friday instead of Saturday to Saturday.</strong> The Saturday departure/Saturday return pattern is peak pricing on every Spanish route. A Friday July 17 departure instead of Saturday July 18 saves £25–45 per person on most routes. A Thursday return instead of Saturday saves similar. Not always possible, but worth checking.<br><br><strong>Almería, Murcia, and Jerez are underpriced alternatives.</strong> Almería (LEI) in south-east Spain is one of Europe's sunniest places and Ryanair from Stansted flies it for £50–70 one-way in summer. The beaches at Cabo de Gata are excellent. Jerez (XRY) in Andalusia gives you sherry bodegas, horses, and flamenco at a fraction of Seville pricing.<br><br><strong>Book now, not in June.</strong> Spain for July and August is in the window where booking this week versus six weeks from now will save a family of four £200–400 in total. The upside of waiting is near-zero. The downside is real."
+    }
+  ],
+  "cta_airport": "LGW",
+  "market": "uk",
+  "published_at": "2026-04-30T11:00:00.000000",
+  "related": [
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK"],
+    ["cheap-flights-to-greece-from-uk-2026", "Cheap Flights to Greece from the UK 2026"],
+    ["cheapest-canary-islands-flights-uk-2026", "Cheapest Canary Islands Flights from UK 2026"]
+  ]
+}

--- a/data/blog/cheap-flights-to-turkey-from-uk-2026.json
+++ b/data/blog/cheap-flights-to-turkey-from-uk-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-flights-to-turkey-from-uk-2026",
+  "emoji": "🇹🇷",
+  "title": "Cheap Flights to Turkey from the UK 2026",
+  "subtitle": "Antalya, Istanbul, Bodrum — Turkey is offering exceptional value this summer",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol",
+  "meta": "Turkey is one of the best-value summer destinations from UK airports in 2026. Find cheap flights to Antalya, Istanbul, Bodrum, and Dalaman — plus when to book and which airlines to use.",
+  "sections": [
+    {
+      "heading": "Why Turkey is offering such good value in 2026",
+      "body": "Turkey has become increasingly popular with UK travellers over the past few years for a straightforward reason: the cost of living there is significantly lower than in the EU, and that difference shows up in everything from restaurant meals to beach-hotel all-inclusives. A week all-inclusive in Antalya costs roughly 40–50% less than an equivalent stay in Spain or Greece.<br><br>On the flight side, Turkish Airlines, easyJet, Jet2, and TUI all compete on UK–Turkey routes, which keeps base fares competitive. <strong>Antalya from Manchester on Jet2 for July is currently showing around £115–145 one-way with bags included</strong> — that's good value for a 4-hour flight in peak school holidays. The same dates to Malaga would be £140–180.<br><br>The practical things to know: British passport holders get a 90-day visa-on-arrival. Turkey is not in the EU so it's outside the roaming zone — a Yesim or Airalo eSIM sorted before you leave is worth the small cost."
+    },
+    {
+      "heading": "Best Turkish destinations from the UK and current fares",
+      "body": "<strong>Antalya (AYT) from Manchester or Gatwick:</strong> The main gateway to the Turkish Riviera. Jet2 from Manchester is the strongest option — currently around £115–145 one-way for July with bags. easyJet from Gatwick is £100–130 one-way without bags. Antalya itself is a big resort city; most people base themselves in Side, Alanya, or Belek nearby. All-inclusive packages here are genuinely good value.<br><br><strong>Istanbul (SAW / IST) from Gatwick or Stansted:</strong> Turkish Airlines from Gatwick and easyJet from Stansted (Sabiha Gökçen, SAW) both serve Istanbul. easyJet fares currently around £75–100 one-way for summer — competitive for a city of this scale. Istanbul is outstanding: Hagia Sophia, the Grand Bazaar, the Bosphorus, and food that rivals any European city. Sabiha Gökçen is on the Asian side — budget 75 minutes to cross to Sultanahmet by public transport.<br><br><strong>Bodrum (BJV) from Gatwick or Manchester:</strong> easyJet from Gatwick around £90–120 one-way for summer. Bodrum is a more upmarket resort town with a different character to Antalya — whitewashed houses, yacht harbour, historic castle. Better for independent travellers than all-inclusive seekers.<br><br><strong>Dalaman (DLM) from Manchester or Birmingham:</strong> Gateway to the Turquoise Coast — Fethiye, Ölüdeniz, Göcek. Jet2 from Manchester around £100–130 one-way for summer. Ölüdeniz's Blue Lagoon is one of the most photographed spots in Turkey and genuinely lives up to expectations."
+    },
+    {
+      "heading": "Practical things to know before booking Turkey",
+      "body": "Turkey is outside the EU, which has a few practical implications. Your mobile operator's EU roaming deal doesn't apply — check your plan before assuming you have data. A travel eSIM from Airalo or Yesim costs £8–15 for a week of data and is worth sorting before you leave. Turkish lira is the local currency; card payments are widely accepted in tourist areas but cash is useful for markets and smaller restaurants.<br><br>The flight time from UK airports to Antalya is 3.5–4 hours, Istanbul 3.5 hours, Bodrum and Dalaman 3.5–4 hours. These are manageable for families with children. Turkish Airlines has a strong reputation for food and service on economy routes if you're on a connecting flight via Istanbul.<br><br>Travel insurance is recommended and standard for Turkey. Check that your policy covers Turkey specifically — some budget policies exclude countries outside the EU by default. This is a minority of policies but worth confirming before you buy."
+    },
+    {
+      "heading": "When to book Turkey for summer 2026",
+      "body": "<strong>Book before mid-May for July and August departures.</strong> Turkey from UK airports is now well established on the summer travel market and prices reflect that — July school holiday fares will reach £180–220 one-way by June if you leave it. Booking now for a July departure locks in fares that are 25–35% below where they'll be in 6 weeks.<br><br><strong>June and September are the sweet spots.</strong> Antalya in June is 30–33°C — hot but not the intense 38–42°C heat of August. September is 28–32°C and noticeably cheaper. If school holidays don't constrain you, June 1–July 4 or September 1–30 deliver the best combination of price, weather, and fewer crowds.<br><br><strong>All-inclusive packages vs flight and hotel separately.</strong> Turkey is one of the destinations where all-inclusive packages from Jet2 or TUI are genuinely worth comparing against booking separately. The all-inclusive model works best in Turkish coastal resorts where the hotel is the experience. For Istanbul, book independently — the all-inclusive model doesn't fit a city trip.<br><br><strong>Jet2 Holidays vs TUI for beach Turkey.</strong> Both operators have strong all-inclusive product in Antalya and Dalaman. Jet2's bag allowance and flexible cancellation often edges TUI on direct comparison. Get quotes from both before committing — the difference on a two-week family holiday can reach £300–500."
+    }
+  ],
+  "cta_airport": "MAN",
+  "market": "uk",
+  "published_at": "2026-04-30T09:48:55.229400",
+  "related": [
+    ["cheap-flights-to-greece-from-uk-2026", "Cheap Flights to Greece from the UK 2026"],
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK"],
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"]
+  ]
+}

--- a/data/blog/cheap-long-haul-flights-uk-summer-2026.json
+++ b/data/blog/cheap-long-haul-flights-uk-summer-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-long-haul-flights-uk-summer-2026",
+  "emoji": "🌍",
+  "title": "Cheap Long-Haul Flights from the UK: Summer 2026",
+  "subtitle": "USA, Southeast Asia, Japan, Canada — which long-haul routes are still at reasonable prices",
+  "airport_names": "Heathrow, Gatwick, Manchester, Birmingham",
+  "meta": "Cheap long-haul flights from UK airports for summer 2026. USA, Japan, Thailand, Canada, Mexico — current fares and which routes still have booking windows before prices peak.",
+  "sections": [
+    {
+      "heading": "Long-haul from the UK in summer 2026 — what's still bookable",
+      "body": "Long-haul fares don't work the same way as European routes. They don't spike as sharply in school holidays because the base price is already high and the demand distribution is more spread out — American families, Japanese tourists, and Australian backpackers all travel on different schedules to UK school holiday families. That means the price premium for booking a transatlantic or Asia-Pacific flight in July, versus May, is proportionally smaller than for a European sun route.<br><br>That said, the best long-haul fares are typically found 3–6 months out, and for summer 2026 departures, April 30 is the outer edge of the good-value window. <strong>USA flights are still bookable at reasonable prices for July and August — but fares are rising weekly.</strong> A London–New York return that was £550 in February is now £680–750. By June it will be £850–1,000. If USA is the plan, this month is the time.<br><br>Southeast Asia remains more price-stable, because summer is actually shoulder season for Thailand, Vietnam, and Bali — it's the wet season. That keeps demand lower and prices more manageable year-round."
+    },
+    {
+      "heading": "USA and Canada: current fares and routes",
+      "body": "<strong>London Heathrow to New York (JFK/EWR):</strong> British Airways, Virgin Atlantic, American, and Delta all compete. Current fares for July: around £600–780 return economy. Premium Economy is £1,200–1,600. The fare gap between carriers has narrowed considerably — compare all four before booking. Norwegian no longer flies this route so budget transatlantic competition is limited; level is gone, Play and Norse Atlantic serve LGW.<br><br><strong>London Gatwick to New York (EWR/JFK) via Norse Atlantic or Play:</strong> Norse Atlantic currently showing £380–480 return for summer from Gatwick. No frills, basic seat, but genuinely cheap for transatlantic. Add-ons push the price up — checked bag each way is £40–60, meals extra. Still ends up cheaper than full-service at equivalent dates.<br><br><strong>London to Los Angeles (LAX):</strong> Around £680–850 return on full-service carriers for summer. Virgin Atlantic from Heathrow is the strongest product on this route. Norwegian from Gatwick around £450–550 return but without the service level. LA in summer (dry, 28°C) is genuinely good but accommodation is expensive.<br><br><strong>London to Toronto or Vancouver (Canada):</strong> Air Transat and Air Canada from Heathrow. Toronto return currently around £580–720 for summer. Canada is often overlooked as a UK summer destination — Vancouver is spectacular, the Rockies are accessible, and the exchange rate is relatively favourable."
+    },
+    {
+      "heading": "Southeast Asia and Japan in summer 2026",
+      "body": "<strong>Thailand (Bangkok BKK) from Heathrow:</strong> Thai Airways, Cathay Pacific via Hong Kong, and Emirates via Dubai all fly this route. Current return fares for summer: £650–850. Bangkok in July is hot and wet — the wet season is June through October. That's not necessarily a deal-breaker (it rains hard for an hour, then stops), but it keeps demand lower and prices more manageable. Chiang Mai and northern Thailand are better in the rainy season than the beach south.<br><br><strong>Japan (Tokyo HND/NRT) from Heathrow:</strong> Japan has been high demand from UK travellers since the yen's weakness became common knowledge. Return fares for summer are £700–950 on JAL, ANA, British Airways. The weak yen makes Japan extraordinary value on the ground — a good dinner in Tokyo costs £15–25. Book before June; Japan summer (30–35°C and humid) is genuinely popular now.<br><br><strong>Bali (DPS) via Singapore or Kuala Lumpur:</strong> Singapore Airlines via Singapore or Malaysia Airlines via KL. Return fares for summer around £750–950. Bali in July/August is peak tourist season (dry season) — it's crowded but beautiful. Book early."
+    },
+    {
+      "heading": "Long-haul booking strategy for summer 2026",
+      "body": "<strong>Book transatlantic now if you haven't.</strong> USA fares for July are still in an acceptable range but they've been rising since March. Every week of delay costs real money on these routes. If New York, LA, or Miami is the plan, book within the next 10 days.<br><br><strong>Consider positioning flights for better long-haul pricing.</strong> Flying London–Madrid and then Madrid–New York can be meaningfully cheaper than a direct LHR–JFK on some dates. Iberia and American both have this route from Madrid at £350–450 one-way for summer. Add a £50 easyJet positioning flight and you've still come out ahead. Worth checking on your specific dates.<br><br><strong>Business class on long-haul has better relative value in summer than economy.</strong> The percentage markup from economy to business on summer long-haul is actually lower than the percentage markup from shoulder to peak in economy. Upgrading a £700 July economy return to business for an extra £600–800 (using points, bid upgrades, or sale fares) is often better value per pound than the equivalent upgrade in February.<br><br><strong>Travel insurance matters more on long-haul.</strong> A medical evacuation from Japan or Thailand can reach £50,000–100,000. Standard travel insurance covers this; trip insurance without medical is not sufficient for long-haul. Buy comprehensive cover at the point of booking — it covers cancellation from booking date onwards."
+    }
+  ],
+  "cta_airport": "LHR",
+  "market": "uk",
+  "published_at": "2026-04-30T11:30:00.000000",
+  "related": [
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK"],
+    ["cheap-flights-to-turkey-from-uk-2026", "Cheap Flights to Turkey from the UK 2026"],
+    ["best-european-city-breaks-summer-2026", "Best European City Breaks Summer 2026"]
+  ]
+}

--- a/data/blog/cheap-summer-flights-europe-from-us-2026.json
+++ b/data/blog/cheap-summer-flights-europe-from-us-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheap-summer-flights-europe-from-us-2026",
+  "emoji": "🌉",
+  "title": "Cheap Summer Flights to Europe from the US 2026",
+  "subtitle": "Transatlantic fares are rising but budget airlines and positioning routes still offer real savings",
+  "airport_names": "New York JFK, Newark, Los Angeles, Boston, Chicago, Miami, Atlanta",
+  "meta": "Find cheap summer flights to Europe from US airports in 2026. London, Paris, Rome, Lisbon, Dublin — current transatlantic fares, budget airline options, and when to book.",
+  "sections": [
+    {
+      "heading": "The transatlantic market in summer 2026 — where fares stand",
+      "body": "Transatlantic travel from the US to Europe has been strong since 2022 and summer 2026 is no different. Demand is high, especially for UK, Ireland, Italy, France, and Portugal. The airlines know this and they've been pricing accordingly. <strong>Budget fares that were $450–550 return in 2023 are now $600–750 on the same routes.</strong><br><br>That said, there's still meaningful variation. Iceland's Play and Norse Atlantic offer genuinely cheap transatlantic seats from New York and Boston to Europe, with the tradeoff being a no-frills experience. Positioning through a European hub can cut costs. And the strongest full-service deals are on routes with genuine airline competition — New York to London, for example, has six carriers competing (BA, Virgin, Delta, United, American, Norse/Play) which keeps a floor price lower than thinner routes.<br><br>April 30 is still a reasonable window to book European summer. Fares will accelerate from late May — when summer demand peaks and airline inventory management removes the lowest buckets. If Europe this summer is the plan, the next three weeks are the time to act."
+    },
+    {
+      "heading": "Best value transatlantic routes and current fares",
+      "body": "<strong>New York (JFK/EWR) to London (LHR/LGW):</strong> The most competitive transatlantic corridor. Norse Atlantic from JFK to LGW around $320–420 one-way for summer economy — genuinely cheap for transatlantic. BA and Virgin from JFK to LHR around $450–600 one-way for summer. The Norse option trades service and flexibility for price — no changes allowed on the cheapest fares, no free bags. For a straightforward trip with no checked luggage, Norse is hard to argue with.<br><br><strong>Boston (BOS) to Dublin (DUB) — Aer Lingus:</strong> Aer Lingus is the dominant carrier on this route and prices competitively. Current summer fares around $420–560 one-way. Dublin has US Preclearance, meaning you clear US customs on departure and land in the US as a domestic flight — significant time saving on the return. Aer Lingus also uses Dublin as a hub for connections to UK and European cities.<br><br><strong>Miami (MIA) to Lisbon (LIS) — TAP Air Portugal:</strong> TAP flies MIA–LIS and uses Lisbon as a hub for connections to Porto, Faro, and Spanish cities. Current summer fares around $480–620 one-way. TAP's free stopover policy in Lisbon means you can break the trip and see the city on the way through at no extra fare cost.<br><br><strong>Los Angeles (LAX) to London (LHR):</strong> Virgin Atlantic and British Airways compete. Current summer return fares around $780–1,050 economy. The longer route (10.5 hours) means Premium Economy becomes more compelling — BA's World Traveller Plus is often $400–600 above economy on LA routes and represents reasonable value for 10 hours in the air."
+    },
+    {
+      "heading": "Budget carrier options for summer 2026",
+      "body": "<strong>Norse Atlantic:</strong> Flies JFK–LGW and JFK–Oslo–LGW. Economy fares with no frills — carry-on only is cheapest, checked bags add $60–90 each way. The seats are standard density but the price is genuinely budget. For travellers who pack light and don't need flexibility, Norse is the cheapest way to get to London from New York. Flies from JFK; connect to Gatwick, not Heathrow — factor in the Gatwick Express to central London.<br><br><strong>Play (Iceland):</strong> Flies via Reykjavik, connecting to European destinations through KEF. Useful if you want to stop in Iceland — Play's stopover policy allows multi-day stays. Can be cheaper than direct routes to secondary European cities (Copenhagen, Prague, Amsterdam) via the KEF hub. Not faster than direct, but often cheaper for mid-tier European destinations.<br><br><strong>Level (defunct) and WOW Air (defunct):</strong> Both were budget transatlantic carriers that collapsed. The lesson: budget transatlantic is a hard business. Norse and Play are operating but check their financial stability if you're booking far ahead. Consider booking with a credit card that covers airline failure for peace of mind."
+    },
+    {
+      "heading": "How to book the best transatlantic deal for summer 2026",
+      "body": "<strong>Book before mid-May for summer departures.</strong> The window is closing. BA, Virgin, United, and Delta have all been steadily removing lower fare buckets from summer inventory since March. The fares that are available today in the $450–600 range from New York to London will be $700–900 by June. This is not a prediction — it's the documented pattern every summer for the past decade.<br><br><strong>Use points for premium cabins, not economy.</strong> Economy award redemptions on transatlantic in summer have terrible availability and high point costs. Premium Economy and Business are better uses of miles — the cash cost for these is high (£1,200–3,000 for PE/J one-way) but the point requirement relative to value is more reasonable. If you have Chase Ultimate Rewards, Amex Membership Rewards, or Capital One miles, check partner award availability for PE/J before booking economy with cash.<br><br><strong>Tuesday and Wednesday departures are consistently cheaper.</strong> Transatlantic fares follow the same day-of-week pattern as domestic. Tuesday and Wednesday departures are 10–20% cheaper than Friday or Sunday on the same route. If you're going for 10 days and can be flexible by 24–48 hours on departure, Wednesday vs Friday saves real money.<br><br><strong>Consider open-jaw itineraries.</strong> Flying into London and out of Paris (or into Rome and out of Barcelona) costs the same or less than return tickets to either city and lets you cover more ground without backtracking. Search JFK–LHR / CDG–JFK as a combined search rather than two separate one-ways."
+    }
+  ],
+  "cta_airport": "JFK",
+  "market": "us",
+  "published_at": "2026-04-30T13:00:00.000000",
+  "related": [
+    ["cheap-flights-from-chicago-ohare-2026", "Cheap Flights from Chicago O'Hare 2026"],
+    ["cheap-flights-from-boston-2026", "Cheap Flights from Boston 2026"],
+    ["fourth-of-july-flights-2026", "Fourth of July Flights 2026"]
+  ]
+}

--- a/data/blog/cheapest-canary-islands-flights-uk-2026.json
+++ b/data/blog/cheapest-canary-islands-flights-uk-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "cheapest-canary-islands-flights-uk-2026",
+  "emoji": "🌴",
+  "title": "Cheapest Canary Islands Flights from the UK 2026",
+  "subtitle": "Tenerife, Lanzarote, Gran Canaria, Fuerteventura — which island, which airport, which price",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol, Edinburgh, Leeds Bradford",
+  "meta": "Find the cheapest Canary Islands flights from UK airports in 2026. Tenerife, Lanzarote, Gran Canaria, Fuerteventura — price comparisons, best booking times, and which island to choose.",
+  "sections": [
+    {
+      "heading": "Why the Canaries are the most reliable value from UK airports",
+      "body": "The Canary Islands are the only sun destination from the UK that works in every month of the year. January in Tenerife is 22°C and sunny. November in Lanzarote is 24°C. That year-round reliability means UK carriers run high-frequency routes 52 weeks a year — and frequency drives competition, which drives prices down.<br><br>What you're getting is effectively a guarantee. The Canaries don't do bad weather. Tenerife averages 320 days of sunshine a year. Fuerteventura has the best beaches in the Atlantic. Gran Canaria has the infrastructure for families and the nightlife for groups. Lanzarote has the volcanic landscape and the wine. Four genuinely different islands, all within 4–4.5 hours of every UK airport.<br><br><strong>Current fares for summer 2026 are still reasonable.</strong> Tenerife (TFS) from Manchester on Jet2 for July is around £110–140 one-way with bags. Lanzarote from Gatwick on easyJet for late June is £80–105 one-way. These will rise 25–35% by mid-May. Book in the next two weeks if summer is the plan."
+    },
+    {
+      "heading": "Island by island: which to choose and current fares",
+      "body": "<strong>Tenerife (TFS — South, Reina Sofía) from Manchester or Gatwick:</strong> Jet2 from Manchester is the best-priced option for summer with bags — currently around £110–140 one-way for July departures. easyJet from Gatwick is £100–130 without bags. Tenerife is the biggest and most varied of the four: Teide National Park, the Masca gorge, proper beaches in the south. Best for families and first-timers.<br><br><strong>Lanzarote (ACE) from Gatwick or Bristol:</strong> easyJet from Gatwick around £75–100 one-way for July. Ryanair from Stansted similar. Lanzarote is unlike anywhere else — black volcanic beaches, César Manrique's architecture, and wine grown in individual volcanic pits. A more interesting choice than Tenerife if you've done the islands before.<br><br><strong>Gran Canaria (LPA) from Manchester or Gatwick:</strong> Jet2 from Manchester around £105–130 one-way for July with bags. easyJet from Gatwick £90–115. Gran Canaria has Maspalomas dunes in the south and Las Palmas city (surprisingly excellent) in the north. Good infrastructure for families.<br><br><strong>Fuerteventura (FUE) from Gatwick or Manchester:</strong> easyJet from Gatwick around £80–105 one-way for July. Jet2 from Manchester similar. The beaches here — Cofete, Sotavento, Corralejo — are some of the best in Europe. The island is flat and not particularly interesting inland, but for a beach holiday it's the obvious choice."
+    },
+    {
+      "heading": "Winter and shoulder season: where the real value is",
+      "body": "The Canaries' biggest price advantage over Spain and Greece is in October through March. When Mallorca is shut and Crete is cold, Tenerife and Lanzarote are 22–24°C and fully open. Off-peak prices reflect the lack of competition — <strong>Lanzarote from Gatwick in November can be found for £50–70 one-way</strong>, return flights under £120 total. For retirees, remote workers, and couples without school-age children, the winter Canaries offer better value per pound than almost any European destination.<br><br>October and November are particularly strong: post-summer prices, pre-Christmas demand, warm enough to swim. Gran Canaria in November is the same temperature as Barcelona in July. Jet2 from regional airports (Leeds Bradford, Birmingham, East Midlands) often has the best winter pricing — less competition than Gatwick routes, but they know their audience and price accordingly."
+    },
+    {
+      "heading": "Practical booking advice for Canary Islands flights",
+      "body": "<strong>Jet2 from regional airports vs easyJet from Gatwick:</strong> For families of four, Jet2's included bags (22kg per person) consistently beat easyJet total prices once you add bag fees. Do the maths on your specific route — the headline fare difference is often £15–20 per person, but the bag calculation wipes that out for anyone travelling with hold luggage.<br><br><strong>Which airport within the island matters:</strong> Tenerife has two airports — TFS (South, Reina Sofía) serves the main resorts. TFN (North, Los Rodeos) is cheaper on some routes but much further from the beach areas. Most UK-direct flights go to TFS. If booking an easyJet flight to TFN, confirm the transfer time to your accommodation.<br><br><strong>Car rental in the Canaries:</strong> Essential for Lanzarote and Fuerteventura, useful but not necessary for Tenerife South resort holidays. Book now through a comparison site with free cancellation — Canary Island car rental prices double between now and June for July pick-ups. A car that's £120/week today will be £220–280 in June.<br><br><strong>Book summer Canaries before May 15.</strong> Manchester to Tenerife and Gatwick to Lanzarote fares are still 20–30% below their peak. That window closes when schools start approaching end-of-term. Anything you're planning for July or August should be booked this month."
+    }
+  ],
+  "cta_airport": "MAN",
+  "market": "uk",
+  "published_at": "2026-04-30T10:30:00.000000",
+  "related": [
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK"],
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"],
+    ["cheap-flights-to-greece-from-uk-2026", "Cheap Flights to Greece from the UK 2026"]
+  ]
+}

--- a/data/blog/fourth-of-july-flights-2026.json
+++ b/data/blog/fourth-of-july-flights-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "fourth-of-july-flights-2026",
+  "emoji": "🎆",
+  "title": "Fourth of July Flights 2026: Book Before June",
+  "subtitle": "July 4 falls on a Saturday — the full extended weekend means high demand on every route",
+  "airport_names": "New York JFK, Newark, Los Angeles, Chicago, Miami, Dallas, Atlanta, Boston, Seattle",
+  "meta": "Fourth of July 2026 falls on a Saturday, creating a 3-day weekend. Flights for July 3-7 are filling up — find the best routes, current fares, and booking advice before prices peak.",
+  "sections": [
+    {
+      "heading": "Why July 4, 2026 creates an extended demand window",
+      "body": "July 4 is a Saturday in 2026. When the 4th falls midweek, demand concentrates on that one day. When it falls on a weekend, demand spreads across four or five days — Thursday July 2 through Monday July 6 or even Tuesday July 7. Airlines understand this and they've been pricing accordingly since February.<br><br>The good news: booking now, April 30, is still early enough that you're not paying last-minute premium. The market for July 4 weekend flights has been moving upward steadily but hasn't hit its ceiling. <strong>A flight that's $160 one-way today will be $220–280 by mid-June.</strong> That's not speculation — it's the consistent historical pattern for holiday weekend domestic flights.<br><br>The strategy is simple: if you know you're travelling over July 4 weekend, the single best thing you can do is book this week. The argument for waiting is essentially zero. Prices don't go down for July 4."
+    },
+    {
+      "heading": "Best value routes for July 4 weekend",
+      "body": "<strong>New York (JFK/LGA/EWR) to Nashville (BNA):</strong> Southwest and American both fly this. Southwest around $120–150 one-way for July 3–4. Nashville over July 4 is exceptional — the Broadway honky-tonks, live music on every corner, and one of the best July 4 fireworks shows in the country on the Cumberland River. Book accommodation now — it fills months out for this weekend.<br><br><strong>Chicago (ORD/MDW) to Denver (DEN):</strong> United and Southwest. Southwest around $115–145 one-way for July 3. Denver has multiple July 4 fireworks shows; the Rocky Mountains are 45 minutes away by car. A long weekend in Colorado around July 4 is consistently one of the best domestic options.<br><br><strong>Los Angeles (LAX) to San Francisco (SFO):</strong> Southwest, Alaska, and United. Southwest around $95–125 one-way but flight time is only 1 hour 20 minutes. Alternatively, the 5.5-hour drive on Highway 1 is one of the great American road trips. SF's July 4 fireworks over the bay are famous. Accommodation in SF books out fast for this weekend — check before buying flights.<br><br><strong>Miami (MIA) to New York (JFK/LGA):</strong> JetBlue and American. JetBlue around $110–140 one-way for July 3–4. New York's July 4 fireworks (the Macy's show, typically over the Hudson) is one of the US's best. If you're in Miami and haven't seen the New York 4th, this is the weekend to do it."
+    },
+    {
+      "heading": "Routes that are already at peak pricing",
+      "body": "Washington D.C. (DCA/IAD) from any major hub is effectively sold out at reasonable prices for July 4. The capital on Independence Day is as demand-saturated as a destination can get — the National Mall fireworks, the monuments, the museums. Flights are $200–300 one-way from New York or Boston. If DC is the plan, you should have booked in January. It's not too late to go — it's just not cheap.<br><br>Las Vegas for July 4 is technically available but the hotel pricing has made the trip expensive regardless of flight cost. The Strip in 42°C July heat with every room at $400/night is a specific kind of experience. Phoenix and Scottsdale are similar. Desert Southwest in July is extreme heat territory — manageable but worth going in knowing what you're booking.<br><br>Hamptons and Fire Island from New York are overpriced regardless of flights — the accommodation market there is entirely separate from the rest of the country's July 4 economy."
+    },
+    {
+      "heading": "How to book July 4 flights smartly",
+      "body": "<strong>Thursday July 2 departure is cheaper than Friday July 3.</strong> Most people leave Friday or Saturday. Thursday evening flights are 15–25% cheaper on most routes and you arrive a full day before the main crowd. If you have flexibility, Thursday departure is the right call.<br><br><strong>Tuesday July 7 return is significantly cheaper than Sunday July 6.</strong> The Sunday July 6 return is peak pricing because everyone wants to get home before the workweek. Monday July 7 is better; Tuesday July 7 is the best value day to return. Check all three options before booking the return.<br><br><strong>Southwest's free bag policy changes the math on this trip.</strong> Southwest allows two checked bags free. For a 4–5 day July 4 trip, you're probably checking bags. On a comparable fare with Spirit or Frontier, you'd pay $55–75 per bag each way. Compare Southwest total to Spirit-with-bags total before booking the cheapest headline.<br><br><strong>Book accommodation before you book flights.</strong> For July 4 weekend, popular destinations — Nashville, Denver, New York, Chicago — have accommodation that sells out faster than flights. Confirm a hotel or Airbnb before locking in a flight, otherwise you might end up with a flight to a destination where every central hotel is gone."
+    }
+  ],
+  "cta_airport": "ORD",
+  "market": "us",
+  "published_at": "2026-04-30T12:00:00.000000",
+  "related": [
+    ["memorial-day-flights-book-now-2026", "Memorial Day Weekend Flights 2026"],
+    ["cheap-flights-from-chicago-ohare-2026", "Cheap Flights from Chicago O'Hare 2026"],
+    ["summer-flights-usa-2026", "Summer Flights USA 2026"]
+  ]
+}

--- a/data/blog/hawaii-vs-caribbean-flights-summer-2026.json
+++ b/data/blog/hawaii-vs-caribbean-flights-summer-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "hawaii-vs-caribbean-flights-summer-2026",
+  "emoji": "🌺",
+  "title": "Hawaii vs Caribbean Flights: Which Is Cheaper in Summer 2026?",
+  "subtitle": "The honest comparison — flight cost, on-the-ground cost, and where you get more for your money",
+  "airport_names": "Los Angeles, San Francisco, Seattle, New York JFK, Chicago, Dallas, Atlanta, Miami",
+  "meta": "Hawaii vs Caribbean summer 2026 — which is cheaper to fly to? Flight cost comparison from US cities, on-the-ground costs, and which destination delivers better value.",
+  "sections": [
+    {
+      "heading": "Flight costs: Hawaii vs Caribbean from major US cities",
+      "body": "The flight cost comparison depends almost entirely on where you're departing from. Hawaii is a 5–10 hour flight from the mainland US — longer from the East Coast, shorter from the West Coast. The Caribbean is 2.5–5 hours from most US cities. That distance difference is the starting point for every cost comparison.<br><br><strong>From the West Coast (LA, San Francisco, Seattle):</strong> Hawaii is the clear winner on flight cost. LA to Honolulu is around $280–380 return on Hawaiian Airlines or Southwest. LA to Jamaica or Dominican Republic is $400–600 return including connections. Hawaii from the West Coast is geographically closer and has far more direct flight options — Hawaiian Airlines, Alaska, United, and Southwest all fly direct LAX–HNL.<br><br><strong>From the East Coast and Midwest (New York, Chicago, Atlanta):</strong> The Caribbean is significantly cheaper to fly to. New York to Montego Bay is $350–500 return. New York to Honolulu is $700–950 return on most carriers. The 10-hour New York–Hawaii flight has less carrier competition than New York–Caribbean, which keeps Hawaii prices higher from the eastern US."
+    },
+    {
+      "heading": "Which is worth the flight cost when you get there",
+      "body": "<strong>Hawaii:</strong> The islands are genuinely extraordinary — volcanic landscapes, snorkeling directly off beaches, Haleakalā sunrise at 10,000 feet, the Road to Hana. Maui is probably the strongest island for first-timers: good beaches, excellent food scene, whale watching in season (not summer). Oahu has Honolulu (more city, more infrastructure), Waikiki, and Pearl Harbor. The Big Island is for lava fields and Kilauea. Kauai is for natural beauty with minimal development.<br><br>On the ground in Hawaii: accommodation is expensive. A hotel in Wailea, Maui runs $350–700/night in summer. A vacation rental in a decent location is $200–400/night. Food is expensive too — Hawaii imports most of its food and costs reflect that. Budget $100–150/day per couple for food and activities beyond accommodation.<br><br><strong>Caribbean:</strong> All-inclusive resorts in Jamaica, Dominican Republic, and Mexico deliver significantly more value per dollar than Hawaii's room-and-meals market. A week at an all-inclusive at a top-rated Punta Cana or Montego Bay resort — flights, hotel, food, drinks, entertainment — can cost $1,800–2,800 per couple. That's genuinely hard to match in Hawaii at any equivalent quality level.<br><br>The Caribbean trade-off: less natural diversity than Hawaii (Aruba is flat; Dominican Republic's interior is accessible but rarely visited), more resort-focused experience, and more variable quality control at all-inclusive properties."
+    },
+    {
+      "heading": "The verdict by traveller type",
+      "body": "<strong>Families from the East Coast on a budget:</strong> Caribbean wins clearly. All-inclusive Punta Cana or Jamaica for a family of four costs $3,000–5,000 total for a week including flights. Hawaii for the same family from New York costs $7,000–12,000. The on-the-ground experience in a good Caribbean all-inclusive is genuinely family-friendly. Hawaii is a dream trip to plan for later when children are old enough to hike and the budget is larger.<br><br><strong>Couples from Los Angeles who want nature:</strong> Hawaii wins clearly. The proximity (5-hour flight), the landscapes (nothing like it in the Americas), and the water quality make it the obvious choice. Maui or Kauai for a week is achievable on a $3,000–5,000 budget from LA if you find a vacation rental rather than a resort.<br><br><strong>Solo travellers or couples who want culture and food:</strong> Neither wins directly — both are more resort-beach than city-culture. If culture is the priority, Europe in summer delivers better value per dollar from the eastern US than either. Oahu's Honolulu has a real city; San Juan in Puerto Rico has a historic centre worth exploring. For pure culture, consider those as alternatives.<br><br><strong>Retirees or remote workers with time and budget flexibility:</strong> Hawaii in shoulder season (September–October, April–May) is when the value-to-experience ratio is best. Avoiding peak summer heat (still warm at 28–30°C, just not the crowded summer peak) and paying 20–30% less on accommodation."
+    },
+    {
+      "heading": "How to book Hawaii or Caribbean for summer 2026 now",
+      "body": "<strong>Hawaii from the West Coast — book before May 20.</strong> Hawaiian Airlines and Alaska have been steadily removing lower-priced inventory from summer Hawaii routes. LAX–HNL for July is currently $280–380 return; that floor will move to $350–450 by June. If West Coast Hawaii is the plan, book within the next three weeks.<br><br><strong>Caribbean from the East Coast — book within the next two weeks.</strong> Summer Caribbean fares from New York, Miami, and Atlanta for June, July, and August are rising weekly. JetBlue to Jamaica and American to Punta Cana for July are both in a window where booking now saves $80–150 per person compared to June booking.<br><br><strong>All-inclusive packages for Caribbean:</strong> The most efficient way to book Caribbean for summer is an all-inclusive package through Apple Vacations, Funjet, or direct via the resort chain. Compare the total cost against booking flight and hotel separately — for most resort areas (not San Juan, not Havana), the all-inclusive wins or is at parity.<br><br><strong>Hawaii vacation rentals vs hotels:</strong> For Hawaii, VRBO and Airbnb rentals in residential areas (Kihei, Maui; Princeville, Kauai) are significantly cheaper than resorts and give kitchen access, which cuts food costs substantially. A $200/night rental with a kitchen and a weekly car rental budget beats a $450/night resort on straight cost, and gives a more authentic experience."
+    }
+  ],
+  "cta_airport": "LAX",
+  "market": "us",
+  "published_at": "2026-04-30T14:00:00.000000",
+  "related": [
+    ["cheap-caribbean-flights-summer-2026", "Cheap Caribbean Flights Summer 2026"],
+    ["cheap-summer-flights-europe-from-us-2026", "Cheap Summer Flights to Europe from the US 2026"],
+    ["memorial-day-flights-book-now-2026", "Memorial Day Weekend Flights 2026"]
+  ]
+}

--- a/data/blog/july-school-holiday-flights-uk-2026.json
+++ b/data/blog/july-school-holiday-flights-uk-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "july-school-holiday-flights-uk-2026",
+  "emoji": "☀️",
+  "title": "July School Holiday Flights from the UK: Book Before June",
+  "subtitle": "School breaks in mid-July — families booking now are getting the last decent fares",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol, Edinburgh, Glasgow",
+  "meta": "July school holiday flights from UK airports are filling up fast. Find the best routes still at reasonable prices for summer 2026 and why booking before June is essential.",
+  "sections": [
+    {
+      "heading": "The July school holiday flight crunch — what's happening right now",
+      "body": "Most English and Welsh schools break up between July 18–22 for summer 2026. That creates a concentrated demand surge on every route from every UK airport starting from that weekend. Airlines know exactly when this happens and price accordingly — the jump from July 17 to July 19 departures is often £40–80 per person on popular sun routes.<br><br><strong>Right now, April 30, is still a reasonable window to book July school holiday travel.</strong> Fares are higher than they were in January but haven't yet hit peak-summer pricing. By late May, popular routes to Spain, Greece, and Turkey will be at or near their annual highs. Families booking today are paying 20–30% less than families booking in June for the same seats.<br><br>The calculation is simple: if you know you're travelling in the last two weeks of July, book this week. The downside of booking now is limited — most major carriers offer date changes on paid fares for a fee, and some allow free changes. The downside of waiting is paying significantly more."
+    },
+    {
+      "heading": "Best value July school holiday routes",
+      "body": "<strong>Faro (FAO), Algarve from Gatwick or Bristol:</strong> easyJet from Gatwick and Ryanair from Stansted both serve Faro. Current fares for July 19–26 departures: around £90–120 one-way. This will reach £150–180 by late May. The Algarve in July is excellent family territory — beaches, water parks, reliable sunshine, and car rental for day trips. Book now.<br><br><strong>Crete (HER) from Gatwick or Manchester:</strong> easyJet from Gatwick around £95–125 one-way for late July. Ryanair from Stansted similar. Crete is big enough to not feel overwhelmed in school holidays — the west of the island around Chania is quieter than the east. A week here with a hire car is one of the best family holiday formats in Greece.<br><br><strong>Tenerife (TFS) from Manchester or Gatwick:</strong> Jet2 from Manchester around £120–150 one-way with bags for late July. The Canaries are the most weather-reliable option from UK airports — Tenerife averages 26°C in July with near-zero rainfall. Good for families where younger children need guaranteed sunshine.<br><br><strong>Turkey (AYT — Antalya) from Manchester:</strong> Jet2 around £125–155 one-way with bags for late July. Better value than Spain at equivalent dates. All-inclusive packages particularly strong from Manchester to Antalya — Jet2 Holidays pricing for a two-week all-inclusive family of four can come in around £2,800–3,400 total, which is competitive."
+    },
+    {
+      "heading": "Routes where the window has already closed",
+      "body": "Some routes are effectively at peak pricing already. <strong>Ibiza (IBZ) from Gatwick</strong> for late July is showing £160–200 one-way on easyJet. If Ibiza is the plan, you should have booked in February. The remaining inventory is priced at a premium because demand is guaranteed regardless.<br><br><strong>Mallorca (PMI) from any UK airport</strong> is similar — Jet2 from Manchester is £140–175 one-way with bags for peak July. Not outrageous for a peak school holiday, but not a deal. Menorca is £80–100 one-way on the same dates — significantly cheaper, quieter, better beaches by most measures.<br><br>If you're flexible on destination but not on dates, the pattern is clear: <strong>the less-famous variant of a popular destination</strong> almost always has better fares in school holidays. Menorca instead of Mallorca. Crete instead of Santorini. Dalaman instead of Bodrum. Same climate, different demand curve."
+    },
+    {
+      "heading": "Practical booking advice for July school holidays",
+      "body": "<strong>Book return flights on a school-day if possible.</strong> Returning Friday July 18 (before most schools break up) or Monday August 3 (not the obvious Saturday return) cuts return leg costs meaningfully. The Saturday-to-Saturday pattern is peak pricing — anything slightly off-pattern saves money.<br><br><strong>Checked bags are non-negotiable for family holidays.</strong> A one-week family of four trip needs hold luggage. Build this into every price comparison — Ryanair or easyJet with bags often costs more than Jet2 with bags included. Jet2 allows 22kg per person; at four people, that's 88kg of luggage allowance, which covers almost any family.<br><br><strong>Car rental in July — book now, not later.</strong> Car rental prices in July at Faro, Heraklion, and Tenerife airports have risen sharply in recent years. Booking now through a comparison site with free cancellation locks in today's rate. The same car that costs £180/week booked today can reach £350–450 if left until late June.<br><br><strong>Travel insurance for school holiday travel.</strong> July is peak hurricane and thunderstorm season in parts of the Mediterranean. Cancellation cover is worth more in July than at quieter times of year. Buy a policy at the same time you book the flight — cover starts from the booking date, not the travel date."
+    }
+  ],
+  "cta_airport": "MAN",
+  "market": "uk",
+  "published_at": "2026-04-30T10:15:33.441800",
+  "related": [
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"],
+    ["cheap-flights-to-greece-from-uk-2026", "Cheap Flights to Greece from the UK 2026"],
+    ["cheapest-canary-islands-flights-uk-2026", "Cheapest Canary Islands Flights from UK 2026"]
+  ]
+}

--- a/data/blog/las-vegas-summer-flight-deals-2026.json
+++ b/data/blog/las-vegas-summer-flight-deals-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "las-vegas-summer-flight-deals-2026",
+  "emoji": "🎰",
+  "title": "Las Vegas Summer Flight Deals 2026",
+  "subtitle": "Vegas in summer is hot but the flight prices are some of the best of the year — here's why",
+  "airport_names": "New York JFK, Los Angeles, Chicago, Dallas, Atlanta, Seattle, Denver",
+  "meta": "Las Vegas summer flight deals 2026 — McCarran fares from major US cities are lower in summer than spring or fall. Find cheap flights to LAS and why Vegas in July can be a good deal.",
+  "sections": [
+    {
+      "heading": "Why summer Vegas flights are cheaper than you'd expect",
+      "body": "Las Vegas is counterintuitively one of the better summer flight deals in the US. Here's why: July and August in Vegas are extreme — 42–45°C, sometimes hotter. That heat suppresses demand from some traveller segments (families with young children, outdoor-activity types, anyone who doesn't like intense heat). The casino-going, pool-party crowd still shows up, but overall demand is lower in peak summer than in spring or fall.<br><br>Airlines know this and price accordingly. <strong>Flights to Vegas in July are often 15–25% cheaper than the same routes in March or October.</strong> New York to Las Vegas in July on Spirit or Frontier can be found under $120 one-way. Compare that to the same route in October (Vegas Grand Prix period) when fares hit $200–250 one-way.<br><br>The Vegas hotel market is the opposite — summer hotel rates are actually reasonable because the convention trade and entertainment crowd is more spread out. The same room that costs $350/night during CES in January or the Formula One race in October can be booked for $150–180/night in July. Summer Vegas is an underrated combination of cheap flights, manageable hotels, and world-class entertainment."
+    },
+    {
+      "heading": "Cheapest flights to Las Vegas this summer",
+      "body": "<strong>New York (JFK/EWR) to Las Vegas (LAS):</strong> Spirit from Newark around $105–135 one-way for July weekday departures. JetBlue from JFK around $130–165 one-way. The 5-hour flight from New York is one of the highest-frequency domestic routes in the US — hundreds of seats daily. That volume keeps prices stable and options plentiful even for last-minute bookings.<br><br><strong>Los Angeles (LAX) to Las Vegas (LAS):</strong> Southwest, Spirit, and Alaska all fly this. Southwest around $65–90 one-way for summer. It's a 1-hour flight and plenty of people drive instead (4 hours on I-15). But for a 4-night trip, the time saving of flying versus driving, plus avoiding fuel and parking costs, often makes the $80 Spirit fare the right call.<br><br><strong>Chicago (ORD/MDW) to Las Vegas (LAS):</strong> Southwest from Midway around $120–150 one-way for summer. United from O'Hare similar. Chicago to Vegas is a busy leisure route — the Midwest has an outsized proportion of Vegas visitors. Midweek departures are significantly cheaper on this route than weekend.<br><br><strong>Atlanta (ATL) to Las Vegas (LAS):</strong> Delta around $140–180 one-way for summer. Spirit also flies ATL–LAS at $100–130. The 4-hour flight from Atlanta is increasingly popular as Vegas consolidates its position as the US's premier entertainment city."
+    },
+    {
+      "heading": "How to Vegas smart in summer — what to actually know",
+      "body": "The pool is the summer day strategy. Every major Vegas hotel has a day-club pool situation that operates from 10am–6pm. The pool itself is free for hotel guests; the poolside experiences range from quiet (Four Seasons, Wynn) to full-scale daytime party (Encore Beach Club, Wet Republic at MGM Grand). The pool is how Vegas is bearable in 42°C heat — you spend the hot part of the day in water, then the evening comes alive after 8pm when temperatures drop to a more manageable 32°C.<br><br>Air conditioning is aggressive everywhere in Vegas. The casinos, hotels, restaurants, and malls are all 20–22°C inside. The only time you're actually in the heat is walking between buildings. The Strip is walkable in small doses but it's longer than it looks — consider Uber between properties rather than walking in the midday heat.<br><br>Budget for more than you think. Vegas hotels charge resort fees ($35–55 per night) on top of quoted room rates. The casino is designed to take money. Food at mid-range Vegas restaurants runs $50–80 per person for dinner. Build a realistic budget before comparing against European beach alternatives."
+    },
+    {
+      "heading": "Las Vegas flight booking strategy",
+      "body": "<strong>Tuesday and Wednesday are the cheapest days to fly into Vegas.</strong> Weekend arrivals — Thursday through Sunday — are premium. Arriving Tuesday morning and leaving Sunday means you catch cheaper inbound fares while still getting a full weekend in Vegas. The Sunday departure is the expensive one — accept it or leave Monday instead.<br><br><strong>Spirit and Frontier for the flight, upgrade the hotel.</strong> Spirit's $100 New York–Vegas fare is spartan but the flight is 5 hours and you're awake for it. Arrive at the Bellagio or Venetian for $180/night instead. The money saved on the flight goes into a hotel with a better pool, better location, and better experience. This is the Vegas budget optimisation formula.<br><br><strong>Avoid holiday weekends unless you're going specifically for the event.</strong> July 4 in Vegas is busy and expensive — hotel rates double, pool parties sell out. Memorial Day weekend is similar. The sweet spot is the Tuesday–Friday of a regular July week when prices at both flights and hotels are their summer minimum.<br><br><strong>Book flights at least 4–6 weeks out for Vegas.</strong> Unlike some domestic destinations, Vegas flights don't reprice dramatically closer to travel — the demand is consistent enough that airlines don't need to discount late inventory on most routes. The best prices are typically 4–8 weeks out on Southwest and Spirit, not last-minute."
+    }
+  ],
+  "cta_airport": "LAS",
+  "market": "us",
+  "published_at": "2026-04-30T13:45:00.000000",
+  "related": [
+    ["cheap-flights-from-chicago-ohare-2026", "Cheap Flights from Chicago O'Hare 2026"],
+    ["fourth-of-july-flights-2026", "Fourth of July Flights 2026"],
+    ["cheap-flights-from-dallas-fort-worth-2026", "Cheap Flights from Dallas Fort Worth 2026"]
+  ]
+}

--- a/data/blog/may-day-bank-holiday-flights-2026.json
+++ b/data/blog/may-day-bank-holiday-flights-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "may-day-bank-holiday-flights-2026",
+  "emoji": "🌿",
+  "title": "May Day Bank Holiday Flights 2026: 4 Days to Book",
+  "subtitle": "May 4 is Monday — there are still decent fares if you move today",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol",
+  "meta": "May Day bank holiday is May 4, 2026 — four days away. Last-minute flight deals still available from UK airports for the long weekend. Here's what's worth booking right now.",
+  "sections": [
+    {
+      "heading": "What's still available 4 days out",
+      "body": "Most people have already booked May Day weekend, but airlines always hold back inventory and reduce prices on unsold seats in the final week before departure. <strong>Right now, Thursday May 1 and Friday May 2 departures are cheaper than Saturday May 3</strong> — if you can leave slightly earlier, you'll find better fares and less chaos at the airport.<br><br>The routes with the most remaining availability tend to be those with high frequencies — Ryanair flies Stansted–Seville eight times a week, for example, so there are more seats to fill. Routes with one daily flight are picked clean much earlier. Stick to high-frequency routes and your options are broader than you'd expect four days out.<br><br>Budget realistically. You're not going to find £39 fares this close. But £70–100 one-way to somewhere like Porto, Seville or Brussels is genuinely achievable and still represents a decent trip."
+    },
+    {
+      "heading": "Best bets for May Day weekend",
+      "body": "<strong>Seville (SVQ) from Stansted — Ryanair:</strong> Around £65–85 one-way for May 1–2 departures. Seville in early May is 24–27°C, the post-Easter tourist rush has thinned, and the city is exceptional. This is probably the best value warm-weather option right now for the bank holiday.<br><br><strong>Porto (OPO) from Stansted — Ryanair:</strong> Around £70–95 one-way for May 1–2. Portugal in May is close to ideal — 20–22°C, minimal rain, excellent food and wine, and costs on the ground that undercut most of Western Europe. Porto over a long weekend is a very strong choice.<br><br><strong>Amsterdam (AMS) from Stansted or Gatwick:</strong> Ryanair and easyJet both serve this. Around £50–75 one-way for May 1. Amsterdam in May is 16°C and green — not beach weather, but a great city. Keukenhof closes mid-May so tulip season is nearly over, but the city itself is worth it at these prices.<br><br><strong>Malaga (AGP) from Gatwick or Manchester:</strong> easyJet from Gatwick showing around £90–120 one-way for May 1–2. Higher than earlier in the year, but Malaga at 22°C in early May is genuinely good. Jet2 from Manchester is competitive at similar pricing with bags included — compare totals."
+    },
+    {
+      "heading": "What to skip at this point",
+      "body": "Ibiza and Mallorca are not worth booking last-minute for May Day. Ryanair and easyJet have priced the remaining seats at near-peak-summer levels — £130–180 one-way from London. The Mediterranean islands have a loyal enough following that airlines don't need to discount to fill the last seats. Save those for a booked-in-advance summer trip.<br><br>Barcelona is similar — £140+ one-way from Gatwick for May 1 departures. The city is excellent but not at that price for a 3-night bank holiday trip. Rome is even worse: Ryanair from Stansted is north of £120 one-way.<br><br>Domestic UK breaks are worth considering if the flight prices feel too high. The Lake District, Scottish Highlands, and Cornwall are all significantly cheaper to reach than flying anywhere in Europe right now, and May is one of the nicer months weather-wise in the UK."
+    },
+    {
+      "heading": "Last-minute booking tips for May Day",
+      "body": "<strong>Book the return leg first.</strong> For last-minute bank holiday travel, the return flight on Tuesday May 5 is often tighter on availability than the outbound. Confirm you can get back before committing to a departure.<br><br><strong>Carry-on only is non-negotiable at this stage.</strong> Ryanair's hold baggage fees at less than 7 days before departure are significantly higher than at-booking prices. A checked bag added now can run £40–60 each way. Three-night trips are manageable in a 10kg cabin bag with planning.<br><br><strong>Check accommodation availability before locking in flights.</strong> Central Porto, Seville and Amsterdam are heavily booked for this weekend. If the hotel you want isn't available, reconsider the destination rather than staying far out. Budget for Airbnb if central hotels are gone.<br><br><strong>Search Monday May 5 returns, not Sunday May 4.</strong> Returning Tuesday after a bank holiday Monday is always cheaper than returning on the Monday itself. Most employers accept Tuesday return; if yours doesn't, the Sunday fare is the only option, but it's meaningfully higher on every route."
+    }
+  ],
+  "cta_airport": "STN",
+  "market": "uk",
+  "published_at": "2026-04-30T08:15:44.112300",
+  "related": [
+    ["spring-bank-holiday-flights-may-2026", "Spring Bank Holiday Flights May 25 2026"],
+    ["uk-bank-holiday-flight-deals", "UK Bank Holiday Flight Deals 2026"],
+    ["easter-weekend-breaks-from-uk", "Best Easter Weekend Breaks from the UK"]
+  ]
+}

--- a/data/blog/memorial-day-flights-book-now-2026.json
+++ b/data/blog/memorial-day-flights-book-now-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "memorial-day-flights-book-now-2026",
+  "emoji": "🇺🇸",
+  "title": "Memorial Day Weekend Flights 2026: Book This Week",
+  "subtitle": "May 23–26 — fares are still reasonable but moving fast. Here's what's still worth booking.",
+  "airport_names": "New York JFK, Newark, Los Angeles, Chicago O'Hare, Miami, Dallas, Atlanta, Boston",
+  "meta": "Memorial Day weekend 2026 flights are still bookable at reasonable fares — but the window closes in the next 10 days. Best routes, current prices, and what to skip.",
+  "sections": [
+    {
+      "heading": "What the Memorial Day flight market looks like right now",
+      "body": "Memorial Day weekend is the unofficial start of summer travel in the US and every airline treats it that way. The Friday before Memorial Day (May 22) and the Tuesday after (May 26) are the two highest-priced travel days of the early summer — airlines have been watching demand build on these dates since February.<br><br>Right now, April 30, you're four weeks out. That's not too late to book, but it's late enough that the easiest deals are gone. <strong>What you can still find:</strong> reasonable fares on high-frequency routes (New York–Miami, Chicago–Denver, Dallas–Vegas), availability on secondary routes that don't sell as fast, and connecting itineraries that have more flexibility built in.<br><br>What you can't find: the $99 cross-country fares that were around in January and February. Those are gone. The floor has moved up. If you're booking now, you're booking at or near Memorial Day pricing — but not quite at the peak that hits in the week before departure."
+    },
+    {
+      "heading": "Routes still worth booking for Memorial Day",
+      "body": "<strong>New York (JFK/LGA/EWR) to Miami (MIA/FLL):</strong> Spirit, Frontier, and JetBlue all fly this. Spirit showing around $95–130 one-way for May 22–23 departures. JetBlue around $120–160. Florida over Memorial Day is warm, the beaches are busy, but the Keys and Miami Beach deliver even with crowds. Return Tuesday May 26 is meaningfully cheaper than Monday May 25.<br><br><strong>Chicago (ORD) to Denver (DEN):</strong> United and Southwest both operate. Southwest around $110–150 one-way for May 22. Denver is an excellent Memorial Day destination — hiking before the summer heat peaks, the Red Rocks area, Estes Park if you drive north. Colorado in late May is genuinely spectacular.<br><br><strong>Dallas (DFW) to Las Vegas (LAS):</strong> American and Southwest. Southwest around $95–135 one-way. Las Vegas over Memorial Day is hot (35°C) and extremely busy — prices at hotels go up sharply. But if Vegas is the plan, flights are still more reasonable than accommodation. Book the hotel before locking in flights.<br><br><strong>Boston (BOS) to Orlando (MCO):</strong> JetBlue and Southwest. JetBlue around $115–145 one-way for May 22–23. Memorial Day Disney World is extremely crowded — Epcot, Hollywood Studios, and Magic Kingdom see multi-hour waits. Water parks or Universal are slightly less overwhelming. Plan ride times carefully."
+    },
+    {
+      "heading": "Routes that have already priced out for Memorial Day",
+      "body": "New York to Los Angeles for Memorial Day weekend is effectively priced at peak levels already. United nonstop from JFK to LAX is running $280–380 one-way for May 22. The demand for this corridor at long weekends is structural — the same people make this trip every year and they book early. At this point, a connecting flight through Denver or Phoenix is worth considering: United via Denver or American via Phoenix can be $60–100 cheaper, adding 2–3 hours but saving real money.<br><br>Cancun and Caribbean routes from the eastern US are also near-ceiling for Memorial Day. JetBlue from JFK to Cancun is $180–240 one-way for May 22. If a beach vacation is the goal, Mexico and the Caribbean are fully priced. The Outer Banks of North Carolina or the Florida Panhandle by car are worth considering instead."
+    },
+    {
+      "heading": "Memorial Day booking tips to maximise value",
+      "body": "<strong>Book Tuesday May 26 return, not Monday May 25.</strong> Monday Memorial Day return flights are priced at a premium because everyone wants to return the same day. Tuesday fares are 20–35% lower on almost every route. Many employers are understanding about a Tuesday return if you frame it as avoiding the chaos.<br><br><strong>Spirit and Frontier headline fares require add-on math.</strong> Spirit's $79 fare to Miami becomes $150+ once you add a carry-on bag ($55–65 at booking for Spirit) and a seat assignment. Compare the Spirit-with-bags total to JetBlue's all-in fare before defaulting to the cheapest headline.<br><br><strong>Flexible dates? Thursday May 21 departure is 20–30% cheaper</strong> than Friday May 22 on most routes. The long weekend starts Friday for most people; if you can leave Thursday evening, you get into destination a day earlier and pay meaningfully less.<br><br><strong>Book the return leg first.</strong> For Memorial Day, return availability on Tuesday is tighter than outbound. Confirm you can get back at a time you're happy with before finalising the outbound booking."
+    }
+  ],
+  "cta_airport": "JFK",
+  "market": "us",
+  "published_at": "2026-04-30T11:45:00.000000",
+  "related": [
+    ["fourth-of-july-flights-2026", "Fourth of July Flights 2026"],
+    ["cheap-caribbean-flights-summer-2026", "Cheap Caribbean Flights Summer 2026"],
+    ["summer-flights-usa-2026", "Summer Flights USA 2026"]
+  ]
+}

--- a/data/blog/spring-bank-holiday-flights-may-2026.json
+++ b/data/blog/spring-bank-holiday-flights-may-2026.json
@@ -1,0 +1,34 @@
+{
+  "slug": "spring-bank-holiday-flights-may-2026",
+  "emoji": "🌸",
+  "title": "Spring Bank Holiday Flights 2026: May 23–26 Deals",
+  "subtitle": "Three and a half weeks to book — prices are still reasonable but moving",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol, Edinburgh",
+  "meta": "Spring bank holiday 2026 is May 25. Flights for the long weekend from UK airports are still bookable at sensible prices — but the window closes in the next 2-3 weeks.",
+  "sections": [
+    {
+      "heading": "Why the spring bank holiday reprices faster than Easter",
+      "body": "The Spring bank holiday on May 25 combines with most schools' half-term break, making it the most demand-compressed holiday window outside of summer. You're not just competing with leisure travellers — the whole country with school-age children wants the same dates. That compresses demand into a narrow window and pushes prices faster than Easter, where adult travellers have more date flexibility.<br><br>The good news is that we're still 25 days out, which is early enough to find reasonable fares on most routes. <strong>The repricing accelerates from around May 10–12</strong> — fares that are £70–90 one-way today will be £110–140 by mid-May on popular sun routes. Booking this week or next saves materially on most itineraries.<br><br>The worst mistake is waiting until the week before. Unlike Easter, where last-minute seat releases sometimes happen, the Spring bank holiday has enough guaranteed demand that airlines don't need to discount late inventory. Book now."
+    },
+    {
+      "heading": "Best destinations for the May bank holiday",
+      "body": "<strong>Menorca (MAH) from Gatwick or Manchester:</strong> easyJet and Jet2 both serve Menorca in May. Unlike Mallorca and Ibiza, Menorca doesn't attract the same peak demand — fares are currently around £65–85 one-way for May 23 departures. The island is 22–24°C, quiet, and genuinely beautiful. It's one of the most consistently underpriced Mediterranean options at bank holidays.<br><br><strong>Faro (FAO), Algarve from Gatwick or Bristol:</strong> Ryanair from Stansted and easyJet from Gatwick showing around £60–80 one-way for May 23. The Algarve in late May is warm (22–24°C), not yet peak crowded, and accommodation is 25–35% cheaper than August. Best overall family value for the bank holiday.<br><br><strong>Marrakech (RAK) from Gatwick or Manchester:</strong> easyJet from Gatwick around £65–85 one-way for May 23. Marrakech at 28–32°C in late May is warm but not oppressively hot. It's genuinely different from a European break — the souks, the food, day trips to the Atlas Mountains — and the flight is only 3.5 hours.<br><br><strong>Rhodes (RHO) from Manchester or Gatwick:</strong> Jet2 from Manchester around £80–105 one-way with bags included. Rhodes in late May is 24–26°C, the sea is warm enough to swim, and the old town is excellent. Return Sunday May 31 is cheaper than Monday June 1 on most carriers."
+    },
+    {
+      "heading": "Already too expensive for late May",
+      "body": "Mallorca from any UK airport has priced in the bank holiday premium — Jet2 from Manchester is already showing £120–155 one-way for May 23, which is near its July peak. Ibiza is worse: £140–190 one-way from London. These routes fill early every year because demand is inelastic — families who've set their hearts on Mallorca will pay whatever it takes.<br><br>Barcelona is similarly gone — £130–170 one-way from Gatwick for May 23. It's a great city but not at bank-holiday-premium prices for a long weekend. The same applies to Lisbon, which has gradually repriced over the past few years as its popularity with UK travellers grew — currently £90–120 one-way.<br><br>If you're comparing Menorca to Mallorca and the price gap is £50+ per person, Menorca wins. Same sea, same climate, half the crowds, better beaches by most measures."
+    },
+    {
+      "heading": "How to book the spring bank holiday well",
+      "body": "<strong>Book by May 8–10 at the latest.</strong> That's the window when fares start moving meaningfully upward. Setting a price alert today and checking every couple of days is the right approach — book when you find a fare you're happy with rather than waiting for a theoretical lower price that may not come.<br><br><strong>Friday May 22 is cheaper than Saturday May 23.</strong> Many schools finish on Friday May 22 at noon. If your children's school lets out early and you can reach the airport by evening, the Friday departure is £20–45 per person cheaper than Saturday on most routes. Over a family of four, that's £80–180 saved.<br><br><strong>Jet2 vs budget carrier total price comparison.</strong> For the bank holiday, Jet2's all-inclusive pricing (bags, seat selection) frequently beats Ryanair or easyJet total cost for families of four. Do the full comparison before defaulting to the cheapest headline fare.<br><br><strong>Return on Tuesday June 2, not Sunday or Monday.</strong> Bank holiday Monday (May 26) and Sunday May 31 returns are the most expensive days. Tuesday June 2 is back to near-normal weekday pricing on most routes — check if your employer or children's school allows a Tuesday return."
+    }
+  ],
+  "cta_airport": "LGW",
+  "market": "uk",
+  "published_at": "2026-04-30T08:48:22.334100",
+  "related": [
+    ["may-half-term-flights-uk", "May Half-Term Flights from UK Airports"],
+    ["may-day-bank-holiday-flights-2026", "May Day Bank Holiday Flights 2026"],
+    ["uk-bank-holiday-flight-deals", "UK Bank Holiday Flight Deals 2026"]
+  ]
+}


### PR DESCRIPTION
UK posts: May Day bank holiday, Spring bank holiday, Greece, Turkey, July school holidays, Canary Islands, Birmingham Airport, Spain, European city breaks, long-haul summer flights.

US posts: Memorial Day, Fourth of July, Chicago O'Hare, Atlanta, Dallas Fort Worth, Europe from US, Caribbean summer, Boston, Las Vegas summer deals, Hawaii vs Caribbean comparison.

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp