### PR TITLE
Disable startup blog auto-generation to stop burning API credits on r…

### DIFF
--- a/app.py
+++ b/app.py
@@ -1471,7 +1471,8 @@ if not (app.debug and os.environ.get('WERKZEUG_RUN_MAIN') != 'true'):
         _scheduler.start()
     except ImportError:
         pass  # APScheduler not installed — run blog_generator.py manually or via cron
-    _startup_blog_generate()
+    # Startup auto-generation disabled — posts are written manually as JSON files
+    # _startup_blog_generate()
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
…edeploy

Posts are now written manually as JSON files — no need to call Claude API on every Render startup or cold start.

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp