### PR TITLE
Recreate school-break-flights-uk-guide blog post

### DIFF
--- a/data/blog/school-break-flights-uk-guide.json
+++ b/data/blog/school-break-flights-uk-guide.json
@@ -1,0 +1,34 @@
+{
+  "slug": "school-break-flights-uk-guide",
+  "emoji": "✏️",
+  "title": "School Break Flights from the UK: Complete Guide 2026",
+  "subtitle": "Easter, May half term, summer, October half term — when to book, where to go, and what to pay",
+  "airport_names": "Gatwick, Stansted, Manchester, Birmingham, Bristol, Edinburgh, Leeds Bradford",
+  "meta": "School break flights UK 2026 — Easter, May half term, summer holidays, October half term. When to book, best routes, and current fares from UK airports.",
+  "sections": [
+    {
+      "heading": "The school holiday flight calendar — and why timing matters",
+      "body": "School holidays are the single biggest driver of flight price spikes in the UK market. When schools break up, demand for family-friendly routes surges overnight — and airlines have been pricing this in for decades. The difference between booking 8 weeks before a school holiday and booking 2 weeks before can easily be £80–150 per person on popular routes. For a family of four, that's £320–600 in unnecessary extra cost.<br><br>The good news: the booking windows are predictable. Airlines release summer schedules in October/November and peak prices form a consistent pattern every year. <strong>If you know when the school breaks are and book 8–12 weeks ahead, you consistently beat families who leave it to the last minute.</strong><br><br>Here's the full 2026 UK school break flight guide — what's coming, what to book, and what things cost right now."
+    },
+    {
+      "heading": "Easter 2026 — April 3 to April 19 (most schools)",
+      "body": "Easter 2026 falls relatively late — Good Friday is April 3, Easter Monday April 6, with most English and Welsh schools off from April 3–17. Scottish schools vary but are broadly similar. <strong>Easter is the first major family flight window of the year and prices reflect that.</strong> Gatwick to Malaga for Easter week is around £130–160 one-way on easyJet. Manchester to Tenerife on Jet2 for Easter is £140–175 one-way with bags. These aren't deals — this is peak Easter pricing.<br><br>The best value during Easter is found on routes that families overlook. Alicante is 10–15% cheaper than Malaga for equivalent dates. Faro (Portugal) is similar in price to Alicante with better beaches for families. The Canaries — particularly Lanzarote and Gran Canaria — are excellent for Easter because the weather is reliable (22–24°C) and families go year-round so the infrastructure is good.<br><br>For Easter 2026 specifically: if you're reading this and haven't booked yet, check what's left. Easter availability from Gatwick and Manchester to popular destinations is thinning fast. Anything still available at £120–140 one-way is reasonable — don't wait for a price drop that won't come."
+    },
+    {
+      "heading": "May half term 2026 — May 25 to May 29",
+      "body": "May half term is the most underrated school break for flight value. The week is shorter than Easter or summer, demand is high but not as compressed, and the Mediterranean weather is genuinely good — Mallorca, Menorca, Crete, and the Algarve are all excellent in late May. <strong>Current fares for May half term from Gatwick or Manchester are 15–25% lower than equivalent Easter fares</strong> — partly because fewer families book this far ahead and partly because the week is short enough that some families don't travel.<br><br>Best routes for May half term: Faro (Algarve, Portugal) is outstanding in late May — warm but not hot, beaches open, restaurants at pre-peak prices. Gatwick to Faro on easyJet around £80–110 one-way for May 25–26. Menorca is another strong choice — quieter than Mallorca but with better beaches for families, and Jet2 from Manchester around £110–130 one-way with bags. Crete (Heraklion) from Gatwick or Manchester around £105–130 one-way — getting busy but still available at reasonable fares.<br><br>Book May half term now. It's four weeks away and prices have been moving upward for six weeks. The seat you book this week is cheaper than the seat you book next week."
+    },
+    {
+      "heading": "Summer holidays 2026 — late July to early September",
+      "body": "Summer is the biggest and most expensive school break. Most English and Welsh schools break up between July 18–22 and return September 3–7. Scottish schools break up earlier — most in late June — which creates a slightly different demand curve for Scottish airports (Edinburgh, Glasgow, Aberdeen).<br><br><strong>For families travelling in peak summer (last two weeks of July, first week of August), this is the most expensive period to fly.</strong> Gatwick to Malaga for late July is £150–185 one-way on easyJet. Manchester to Ibiza on Jet2 is £160–200 one-way with bags. These are the ceiling prices — they don't go much higher, but they don't come down either once you're inside 6 weeks.<br><br>Where summer value still exists for families: Turkey (Antalya) from Manchester or Birmingham on Jet2 consistently offers more hotel value per pound than Spain — all-inclusive resorts are exceptional value and Jet2 Holidays packages to Turkey often undercut equivalent Spain packages by £200–400 per family. Bulgaria (Sofia/Varna) is dramatically underpriced — easyJet to Sofia and budget airlines to Varna offer some of the cheapest European beach options. Croatia (Split, Dubrovnik) is getting expensive but still cheaper than peak Mallorca.<br><br>If you haven't booked summer yet, the window is closing. Late June and early July departure dates still have reasonable availability. Peak late July/August is filling fast."
+    }
+  ],
+  "cta_airport": "LGW",
+  "market": "uk",
+  "published_at": "2026-03-10T09:00:00.000000",
+  "related": [
+    ["july-school-holiday-flights-uk-2026", "July School Holiday Flights from the UK 2026"],
+    ["cheap-flights-april-bank-holiday-uk", "Cheap Flights April Bank Holiday UK"],
+    ["cheap-flights-to-spain-from-uk-2026", "Cheap Flights to Spain from the UK 2026"]
+  ]
+}


### PR DESCRIPTION
Post was lost in a Render ephemeral filesystem wipe. Recreating at the same slug to recover GSC ranking signal — this was the site's highest-impression post.

https://claude.ai/code/session_01Hv9mSXH24jJ8yoVp1wNBSp