### PR TITLE
Fix city and airport names being truncated on flight cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -215,9 +215,6 @@
     font-size: 1.05rem;
     font-weight: 700;
     color: #eaf0ff;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   .flight-iata {
     background: rgba(110,168,255,.18);
@@ -233,9 +230,6 @@
   .flight-airport-name {
     font-size: 0.75rem;
     color: #5a6e9e;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   .flight-right {
     display: flex;


### PR DESCRIPTION
Remove white-space:nowrap + overflow:hidden + text-overflow:ellipsis from .flight-city and .flight-airport-name so full names display.

https://claude.ai/code/session_01FPgEgspqwab1ZvJCDHYLW8