### PR TITLE
Phase 1 SEO & performance fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -371,7 +371,9 @@ except Exception as _e:
 # ---- Template globals ----
 @app.context_processor
 def inject_now():
-    return {"current_year": datetime.utcnow().year}
+    # canonical_url strips query parameters to avoid duplicate-content issues
+    canonical_url = f"{request.scheme}://{request.host}{request.path}"
+    return {"current_year": datetime.utcnow().year, "canonical_url": canonical_url}
 
 # ---- Built-in minimal fallback (last line of defence) ----
 DEFAULT_AIRPORTS = [
@@ -1336,7 +1338,7 @@ def sitemap():
         ('https://getmeoutofhere.live/terms',     '0.3', today,  'yearly'),
     ]
 
-    # Blog posts — use published_at date if available
+    # Blog posts — prefer updated_at for lastmod, fallback to published_at
     blog_dir = os.path.join(app.root_path, 'data', 'blog')
     if os.path.isdir(blog_dir):
         for fn in sorted(os.listdir(blog_dir)):
@@ -1347,11 +1349,12 @@ def sitemap():
             try:
                 with open(os.path.join(blog_dir, fn)) as f:
                     post = json.load(f)
-                if post.get('published_at'):
-                    lastmod = post['published_at'][:10]
+                date_str = post.get('updated_at') or post.get('published_at')
+                if date_str:
+                    lastmod = date_str[:10]
             except Exception:
                 pass
-            pages.append((f'https://getmeoutofhere.live/blog/{slug}', '0.8', lastmod, 'monthly'))
+            pages.append((f'https://getmeoutofhere.live/blog/{slug}', '0.8', lastmod, 'weekly'))
 
     # SEO airport landing pages
     for code in SEO_AIRPORTS:
@@ -1386,6 +1389,10 @@ def serve_verification_file2():
 @app.route('/robots.txt')
 def robots_txt():
     return send_from_directory(app.root_path, 'robots.txt')
+
+@app.errorhandler(404)
+def page_not_found(e):
+    return render_template('404.html'), 404
 
 # Optional: quick debug route
 

--- a/blog_generator.py
+++ b/blog_generator.py
@@ -1537,6 +1537,7 @@ def generate_post(topic: dict, dry_run: bool = False) -> dict | None:
         "market":        topic.get('market', 'uk'),
         "related":       _build_related(topic['slug']),
         "published_at":  datetime.now().isoformat(),
+        "updated_at":    datetime.now().isoformat(),
     }
 
     if not post['sections']:

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+
+{% block title %}Page Not Found | GetMeOutOfHere.Live{% endblock %}
+{% block meta_description %}This page doesn't exist — but cheap flights do. Head back to GetMeOutOfHere.Live and search for the cheapest places to fly from your airport.{% endblock %}
+
+{% block content %}
+<style>
+  .not-found-wrap {
+    text-align: center;
+    padding: 60px 20px 40px;
+  }
+  .not-found-code {
+    font-size: 6rem;
+    font-weight: 900;
+    line-height: 1;
+    background: linear-gradient(135deg, #6ea8ff, #82ffd2);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 12px;
+  }
+  .not-found-wrap h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #eaf0ff;
+    margin-bottom: 10px;
+  }
+  .not-found-wrap p {
+    color: #9fb0ff;
+    font-size: 0.95rem;
+    max-width: 420px;
+    margin: 0 auto 32px;
+    line-height: 1.6;
+  }
+  .quick-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 32px;
+  }
+  .quick-link {
+    background: rgba(110,168,255,.1);
+    border: 1px solid rgba(110,168,255,.25);
+    border-radius: 12px;
+    padding: 10px 18px;
+    color: #9fb0ff;
+    text-decoration: none;
+    font-size: 0.88rem;
+    font-weight: 600;
+    transition: background .15s, border-color .15s, color .15s;
+  }
+  .quick-link:hover {
+    background: rgba(110,168,255,.2);
+    border-color: rgba(110,168,255,.5);
+    color: #eaf0ff;
+  }
+  .btn-home {
+    display: inline-block;
+    background: linear-gradient(135deg, #3b7dd8 0%, #1a55b0 100%);
+    color: #fff;
+    border-radius: 12px;
+    font-weight: 700;
+    font-size: 1rem;
+    padding: 13px 32px;
+    text-decoration: none;
+    transition: opacity .2s, transform .1s;
+  }
+  .btn-home:hover { opacity: .88; transform: translateY(-1px); color: #fff; }
+</style>
+
+<div class="not-found-wrap">
+  <div class="not-found-code">404</div>
+  <h1>This page took a wrong turn.</h1>
+  <p>The page you're looking for doesn't exist or may have moved. But cheap flights definitely do — let's find you one.</p>
+
+  <a href="{{ url_for('index') }}" class="btn-home">
+    <i class="fa fa-plane me-2"></i>Search cheap flights
+  </a>
+
+  <div class="quick-links">
+    <a href="{{ url_for('blog_index') }}" class="quick-link"><i class="fa fa-compass me-1"></i>Flight deal guides</a>
+    <a href="{{ url_for('faq') }}" class="quick-link"><i class="fa fa-circle-info me-1"></i>FAQ</a>
+    <a href="{{ url_for('about') }}" class="quick-link"><i class="fa fa-house me-1"></i>About</a>
+  </div>
+
+  <div style="margin-top: 40px; display: flex; flex-wrap: wrap; gap: 8px; justify-content: center;">
+    {% set popular = [('LHR','London Heathrow'),('MAN','Manchester'),('EDI','Edinburgh'),('BHX','Birmingham'),('BRS','Bristol')] %}
+    {% for code, name in popular %}
+    <a href="{{ url_for('seo_airport', code=code) }}" class="quick-link" style="font-size:0.8rem; padding:8px 14px;">
+      <i class="fa fa-plane-departure me-1"></i>Flights from {{ name }}
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,11 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnect to external resources for faster load -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://plausible.io" crossorigin>
+  <link rel="dns-prefetch" href="https://flagcdn.com">
   <title>{% block title %}GetMeOutOfHere.Live{% endblock %}</title>
   <meta name="description" content="{% block meta_description %}Find the cheapest places to fly from your airport — no destination needed.{% endblock %}">
   <meta name="google-site-verification" content="D7SPk9eeETSx8-YyaDxrnSkVB7tn6kpBQffDLpUrR0s" />
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2050826457723021" crossorigin="anonymous"></script>
-  <link rel="canonical" href="{{ request.url }}" />
+  <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 
   <!-- Open Graph -->
@@ -15,7 +20,7 @@
   <meta property="og:site_name" content="GetMeOutOfHere.Live" />
   <meta property="og:title" content="{% block og_title %}GetMeOutOfHere.Live{% endblock %}" />
   <meta property="og:description" content="{% block og_description %}Find the cheapest places to fly from your airport — no destination needed.{% endblock %}" />
-  <meta property="og:url" content="{{ request.url }}" />
+  <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:image" content="{% block og_image %}https://getmeoutofhere.live/static/og-image.webp{% endblock %}" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +52,7 @@
   {% endblock %}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="{{ url_for('static', filename='index.css') }}" rel="stylesheet" />
-  <script defer src="{{ url_for('static', filename='fontawesome-free-6.7.2-web/js/all.js') }}"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='fontawesome-free-6.7.2-web/css/all.min.css') }}">
   <script defer data-domain="getmeoutofhere.live" src="https://plausible.io/js/script.js"></script>
   <style>
     body {

--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -32,7 +32,7 @@
   "url": "https://getmeoutofhere.live/blog/{{ post.slug }}",
   "mainEntityOfPage": "https://getmeoutofhere.live/blog/{{ post.slug }}"{% if post.published_at %},
   "datePublished": "{{ post.published_at[:10] }}",
-  "dateModified": "{{ post.published_at[:10] }}"{% endif %}
+  "dateModified": "{{ (post.updated_at or post.published_at)[:10] }}"{% endif %}
 }
 </script>
 <script type="application/ld+json">


### PR DESCRIPTION
- Fix canonical URL bug: use request.path (no query params) instead of request.url so search result pages don't create duplicate canonicals
- Fix og:url to use same clean URL as canonical
- Add preconnect/dns-prefetch hints for CDN, AdSense, Plausible, flagcdn
- Switch FontAwesome from JS bundle (1.6MB) to CSS (73KB) — 95% reduction
- Add custom branded 404 page with search CTA and popular airport links
- Add 404 error handler in app.py
- Add updated_at field to blog post schema in blog_generator.py
- Use updated_at (over published_at) for Article dateModified schema
- Use updated_at for sitemap lastmod; bump blog changefreq to weekly

https://claude.ai/code/session_01GMNeuVGiS3YgBL1nKEoJD6