### PR TITLE
Change rent a car link color to dark green for visibility

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -918,7 +918,7 @@
             <a class="hotel-link"
                href="https://localrent.tpm.li/mXHNfspd"
                target="_blank" rel="noopener"
-               style="color:#82ffd2;">
+               style="color:#16a34a;">
               <i class="fa fa-car"></i> Rent a car
             </a>
             <a class="hotel-link klook-link"


### PR DESCRIPTION
#82ffd2 (very light green) → #16a34a (dark green) on the flight card rent a car link

https://claude.ai/code/session_01LQ44L61HW4A8mgXFtjGHdU