### PR TITLE
Improve mobile LCP and page load performance

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,9 +50,12 @@
   }
   </script>
   {% endblock %}
+  <link rel="preconnect" href="https://images.unsplash.com" crossorigin>
+  <link rel="preload" as="image" href="{{ url_for('static', filename='alejandro-pinero-amerio-Lx3l-Hf_P5I-unsplash.webp') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="{{ url_for('static', filename='index.css') }}" rel="stylesheet" />
-  <link rel="stylesheet" href="{{ url_for('static', filename='fontawesome-free-6.7.2-web/css/all.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='fontawesome-free-6.7.2-web/css/all.min.css') }}" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="{{ url_for('static', filename='fontawesome-free-6.7.2-web/css/all.min.css') }}"></noscript>
   <script defer data-domain="getmeoutofhere.live" src="https://plausible.io/js/script.js"></script>
   <style>
     body {

--- a/templates/index.html
+++ b/templates/index.html
@@ -835,7 +835,7 @@
     <div class="photo-mosaic">
       <img class="photo-tall"
            src="{{ url_for('static', filename='alejandro-pinero-amerio-Lx3l-Hf_P5I-unsplash.webp') }}"
-           alt="Travel destination" loading="lazy">
+           alt="Travel destination" fetchpriority="high">
       <img src="{{ url_for('static', filename='md-arafat-ul-alam-bnrouu6uqaM-unsplash.webp') }}"
            alt="Flight view" loading="lazy">
       <img src="https://images.unsplash.com/photo-1436491865332-7a61a109cc05?w=600&q=80&auto=format&fit=crop"


### PR DESCRIPTION
- Fix LCP image: remove loading="lazy", add fetchpriority="high" so the hero image is fetched immediately instead of being deprioritised
- Add <link rel="preload"> for the hero image so the browser starts fetching it before the render tree is built
- Add preconnect for images.unsplash.com to reduce DNS lookup latency
- Defer FontAwesome CSS (73KB) using media="print" trick so it no longer blocks first paint — icons load after content is visible

https://claude.ai/code/session_01VPTuaFHnQzbqb1rVsG9jeZ