### PR TITLE
Fix heading hierarchy and add static asset cache headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -370,6 +370,14 @@ except Exception as _e:
     amadeus = None
     app.logger.warning("Amadeus client not initialised: %s", _e)
 
+# ---- Cache headers for static assets ----
+@app.after_request
+def add_cache_headers(response):
+    if request.path.startswith('/static/'):
+        response.cache_control.max_age = 604800  # 1 week
+        response.cache_control.public = True
+    return response
+
 # ---- Force HTTPS in production ----
 @app.before_request
 def redirect_to_https():

--- a/templates/index.html
+++ b/templates/index.html
@@ -981,7 +981,7 @@
   <!-- EMAIL CAPTURE -->
   {% if form_data.origin_code %}
   <div class="email-capture">
-    <h3><i class="fa fa-bell me-2" style="color:#3b7dd8"></i>Get price alerts</h3>
+    <h2 style="font-size:1.1rem; font-weight:700;"><i class="fa fa-bell me-2" style="color:#3b7dd8"></i>Get price alerts</h2>
     <p>
       We'll email you when cheap flights from
       <strong style="color:#1a2744">{{ origin_label or form_data.origin }}</strong> drop even lower.
@@ -1068,7 +1068,7 @@
 {% if not form_data.origin_code %}
 <div class="newsletter-section">
   <div class="newsletter-box">
-    <h3><i class="fa fa-envelope me-2" style="color:#3b7dd8"></i>Get the week's cheapest deals to your inbox</h3>
+    <h2 style="font-size:1.1rem; font-weight:700;"><i class="fa fa-envelope me-2" style="color:#3b7dd8"></i>Get the week's cheapest deals to your inbox</h2>
     <p>Free. No spam. The best flight deals from your airport, every week.</p>
     <form id="newsletterForm" onsubmit="handleNewsletter(event)" autocomplete="off">
       <input type="hidden" id="nl_airport_code" name="airport_code" value="">


### PR DESCRIPTION
- Fix h3 heading elements that skipped h2 (h1 → h3 is invalid hierarchy) 'Get price alerts' and 'Get the week's cheapest deals' changed to h2
- Add Cache-Control: public, max-age=604800 (1 week) for all /static/ assets — browser was re-downloading CSS, images, fonts on every visit

https://claude.ai/code/session_01VPTuaFHnQzbqb1rVsG9jeZ