### PR TITLE
Expand trust pages and add contact page to address AdSense low value …

### DIFF
--- a/app.py
+++ b/app.py
@@ -780,6 +780,10 @@ def privacy():
 def terms():
     return render_template('terms.html')
 
+@app.route('/contact')
+def contact():
+    return render_template('contact.html')
+
 # ---- Autocomplete API: Amadeus -> local file -> built-in defaults ----
 @app.route('/api/airports', methods=['GET'])
 def get_airports():

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,13 +1,47 @@
 {% extends "base.html" %}
 {% block title %}About | GetMeOutOfHere.Live{% endblock %}
-{% block meta_description %}GetMeOutOfHere.Live is a free flight finder that shows you the cheapest places to fly from your airport — no destination needed.{% endblock %}
+{% block meta_description %}GetMeOutOfHere.Live is a free flight finder that shows you the cheapest places to fly from your airport — no destination needed. Learn how it works, who built it, and why.{% endblock %}
 {% block og_title %}About | GetMeOutOfHere.Live{% endblock %}
 {% block og_description %}GetMeOutOfHere.Live is a free flight finder that shows you the cheapest places to fly from your airport — no destination needed.{% endblock %}
 {% block content %}
-<div class="container py-5">
-  <h1>About</h1>
-  <p><strong>GetMeOutOfHere.Live</strong> is a simple flight finder built to show you the cheapest places you can fly to — no destination needed. Just choose your airport and dates, and we’ll bring you the lowest fares available.</p>
-  <p>We partner with <strong>Travelpayouts</strong> to pull real-time flight prices from airlines and booking sites. When you book, we may earn a small commission — at no extra cost to you.</p>
-  <p>Fast. Simple. No endless tabs. Just cheap flights, straight up.</p>
+<div class="container py-5" style="max-width: 800px;">
+
+  <h1 class="mb-3">About GetMeOutOfHere.Live</h1>
+  <p class="lead text-muted mb-5">A free flight search tool built around one idea: sometimes you just want to go somewhere cheap — and you don't care where.</p>
+
+  <h2 class="h4 mb-3">What we do</h2>
+  <p>GetMeOutOfHere.Live is a flight discovery tool that works differently from most flight search engines. Instead of asking "where do you want to go?", it asks "where are you flying from?" — then shows you every affordable destination you can reach from your airport on your chosen dates.</p>
+  <p>You pick your home airport, your departure window, and the number of passengers. We do the rest — pulling real-time fares from hundreds of airlines and booking sites to show you the cheapest options available right now. No destination required. No endless tab-switching. Just cheap flights, ranked by price.</p>
+
+  <h2 class="h4 mt-5 mb-3">How it works</h2>
+  <ol class="mb-4">
+    <li class="mb-2"><strong>Enter your airport and dates</strong> — use the search form on the homepage. We support hundreds of airports across the UK, Europe, North America, Asia, and beyond.</li>
+    <li class="mb-2"><strong>We fetch live prices</strong> — our system queries real-time flight data via Travelpayouts, which aggregates fares from major airlines and online travel agencies including Ryanair, easyJet, British Airways, Wizz Air, Lufthansa, and more.</li>
+    <li class="mb-2"><strong>Results are ranked by price</strong> — you see the cheapest destinations first. Filter by price, airline, or destination type to narrow down your options.</li>
+    <li class="mb-2"><strong>Click to book</strong> — when you find a fare you like, we send you directly to the airline or booking site to complete your reservation securely. We never handle payment details ourselves.</li>
+  </ol>
+
+  <h2 class="h4 mt-5 mb-3">Why we built this</h2>
+  <p>We built GetMeOutOfHere.Live for the times when you need a break but haven't decided where to go. Maybe you have a long weekend free and want to escape somewhere warm. Maybe you're a flexible traveller hunting for the best value. Maybe you're just curious what's cheap from your airport right now.</p>
+  <p>Traditional flight search engines require a destination before they show you anything. That means you're constantly opening new tabs, entering the same dates over and over, and manually comparing prices across dozens of routes. We cut through all of that by aggregating everything in one place and letting the price lead the decision.</p>
+
+  <h2 class="h4 mt-5 mb-3">Where our prices come from</h2>
+  <p>All flight prices on GetMeOutOfHere.Live are sourced in real time from <a href="https://www.aviasales.com" target="_blank" rel="noopener">Aviasales</a> via the <strong>Travelpayouts</strong> affiliate network. Travelpayouts is one of the largest travel affiliate platforms in the world, aggregating fares from hundreds of airlines and booking sites.</p>
+  <p>Prices are pulled fresh each time you search and are subject to availability and change without notice — just like prices on the airline's own website. We always recommend clicking through to confirm the current fare before making any travel plans.</p>
+
+  <h2 class="h4 mt-5 mb-3">Affiliate disclosure</h2>
+  <p>GetMeOutOfHere.Live is free to use. We earn a small commission from Travelpayouts when you click through and complete a booking with one of their partner airlines or travel sites. This commission is paid by the travel provider — it does not add any cost to your ticket price.</p>
+  <p>This affiliate relationship does not influence which flights we show or how we rank them. Results are always sorted by price, not by commission rate.</p>
+
+  <h2 class="h4 mt-5 mb-3">Our travel blog</h2>
+  <p>Alongside the flight search tool, we publish a <a href="/blog">travel deals blog</a> covering topics like the cheapest routes from major airports, how to find last-minute deals, the best times to book for peak season travel, and destination guides for budget-conscious travellers. New posts go up regularly — bookmark the blog or <a href="/#subscribe">subscribe for alerts</a> to stay up to date.</p>
+
+  <h2 class="h4 mt-5 mb-3">Contact us</h2>
+  <p>Have a question, found a bug, or want to suggest a feature? We'd love to hear from you. Reach us at <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a> or visit our <a href="/contact">contact page</a>.</p>
+
+  <div class="mt-5 p-4 rounded" style="background:#f0f4ff; border-left: 4px solid #3b7dd8;">
+    <p class="mb-0" style="color:#1a2744;"><strong>GetMeOutOfHere.Live</strong> &nbsp;·&nbsp; Free flight search &nbsp;·&nbsp; Real-time prices via Travelpayouts &nbsp;·&nbsp; No booking fees &nbsp;·&nbsp; <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a></p>
+  </div>
+
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -136,7 +136,7 @@
         <a href="{{ url_for('faq') }}" class="top-nav-link">FAQ</a>
         <a href="{{ url_for('privacy') }}" class="top-nav-link">Privacy</a>
         <a href="{{ url_for('terms') }}" class="top-nav-link">Terms</a>
-        <a href="mailto:hello@getmeoutofhere.live" class="top-nav-link">Contact</a>
+        <a href="{{ url_for('contact') }}" class="top-nav-link">Contact</a>
       </div>
     </div>
   </nav>
@@ -153,7 +153,7 @@
       <a href="{{ url_for('faq') }}" style="color:#3b7dd8;">FAQ</a>
       <a href="{{ url_for('privacy') }}" style="color:#3b7dd8;">Privacy</a>
       <a href="{{ url_for('terms') }}" style="color:#3b7dd8;">Terms</a>
-      <a href="mailto:hello@getmeoutofhere.live" style="color:#3b7dd8;">Contact</a>
+      <a href="{{ url_for('contact') }}" style="color:#3b7dd8;">Contact</a>
     </div>
     © {{ current_year if current_year else 2026 }} GetMeOutOfHere.Live &nbsp;·&nbsp;
     Prices sourced from <a href="https://www.aviasales.com" target="_blank" rel="noopener" style="color:#3b7dd8;">Aviasales</a>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Contact | GetMeOutOfHere.Live{% endblock %}
+{% block meta_description %}Get in touch with GetMeOutOfHere.Live. Have a question, found a bug, or want to suggest a feature? We'd love to hear from you.{% endblock %}
+{% block og_title %}Contact | GetMeOutOfHere.Live{% endblock %}
+{% block og_description %}Contact GetMeOutOfHere.Live — free flight finder. Have a question or feedback? Get in touch.{% endblock %}
+{% block content %}
+<div class="container py-5" style="max-width: 700px;">
+
+  <h1 class="mb-2">Contact Us</h1>
+  <p class="lead text-muted mb-5">Got a question, found a bug, or have a suggestion? We'd love to hear from you.</p>
+
+  <div class="row g-4 mb-5">
+    <div class="col-12 col-md-6">
+      <div class="p-4 rounded h-100" style="background:#f0f4ff; border: 1px solid #d0dcf7;">
+        <div class="mb-3"><i class="fa fa-envelope fa-lg" style="color:#3b7dd8;"></i></div>
+        <h2 class="h5 mb-2">Email</h2>
+        <p class="text-muted mb-2">The best way to reach us. We aim to reply within 1–2 business days.</p>
+        <a href="mailto:hello@getmeoutofhere.live" class="fw-bold" style="color:#3b7dd8;">hello@getmeoutofhere.live</a>
+      </div>
+    </div>
+    <div class="col-12 col-md-6">
+      <div class="p-4 rounded h-100" style="background:#f0f4ff; border: 1px solid #d0dcf7;">
+        <div class="mb-3"><i class="fa fa-circle-question fa-lg" style="color:#3b7dd8;"></i></div>
+        <h2 class="h5 mb-2">FAQ</h2>
+        <p class="text-muted mb-2">Looking for quick answers? Check our frequently asked questions first.</p>
+        <a href="/faq" class="fw-bold" style="color:#3b7dd8;">Visit the FAQ &rarr;</a>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="h4 mb-3">What can we help with?</h2>
+  <ul class="mb-5" style="line-height: 2;">
+    <li><strong>Flight search questions</strong> — how the tool works, supported airports, search tips</li>
+    <li><strong>Booking issues</strong> — problems clicking through to a partner site</li>
+    <li><strong>Bug reports</strong> — something not working as expected on the site</li>
+    <li><strong>Feature requests</strong> — something you'd love to see added</li>
+    <li><strong>Privacy or data requests</strong> — accessing or deleting your data (see our <a href="/privacy">Privacy Policy</a>)</li>
+    <li><strong>Press or partnership enquiries</strong> — affiliate or media related questions</li>
+  </ul>
+
+  <div class="p-4 rounded" style="background:#fff8e6; border: 1px solid #f0d080;">
+    <p class="mb-0"><i class="fa fa-circle-info me-2" style="color:#c89000;"></i><strong>Booking issues?</strong> If you have a problem with a flight you booked, please contact the airline or travel provider directly — we don't process bookings and can't modify or cancel reservations on your behalf.</p>
+  </div>
+
+</div>
+{% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,13 +1,124 @@
 {% extends "base.html" %}
 {% block title %}Privacy Policy | GetMeOutOfHere.Live{% endblock %}
-{% block meta_description %}Our privacy policy: we don't track you across the web, we don't sell your data, and bookings are handled securely by our travel partners.{% endblock %}
+{% block meta_description %}Privacy policy for GetMeOutOfHere.Live. Learn what data we collect, how we use it, and what third-party services we use — including Plausible Analytics, Brevo, and Travelpayouts.{% endblock %}
 {% block og_title %}Privacy Policy | GetMeOutOfHere.Live{% endblock %}
-{% block og_description %}Our privacy policy: we don't track you across the web, we don't sell your data, and bookings are handled securely by our travel partners.{% endblock %}
+{% block og_description %}Privacy policy for GetMeOutOfHere.Live. We respect your privacy — no tracking across the web, no selling your data.{% endblock %}
 {% block content %}
-<div class="container py-5">
-  <h1>Privacy Policy</h1>
-  <p>We respect your privacy. We don’t collect personal details unless you choose to share them (like subscribing to updates).</p>
-  <p>We use simple analytics (like Plausible) to see how the site is used — but we don’t track you across the web or sell your data.</p>
-  <p>When you click “Book Now,” you’re taken to a trusted travel partner’s website. Any personal or payment information is handled there, not by us.</p>
+<div class="container py-5" style="max-width: 800px;">
+
+  <h1 class="mb-2">Privacy Policy</h1>
+  <p class="text-muted mb-5"><small>Last updated: April 2026</small></p>
+
+  <p>This Privacy Policy explains how GetMeOutOfHere.Live ("we", "our", or "us") collects, uses, and protects information when you use our website at <strong>getmeoutofhere.live</strong>.</p>
+  <p>We take your privacy seriously. We collect only what is necessary to operate the service, and we never sell your personal data to third parties.</p>
+
+  <h2 class="h4 mt-5 mb-3">1. Information we collect</h2>
+
+  <h3 class="h6 mt-4 mb-2">a) Information you provide voluntarily</h3>
+  <p>If you sign up for flight deal alerts, we collect your <strong>email address</strong> and optionally your preferred departure airport. You can unsubscribe at any time using the link in any email we send, or by emailing us at <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a>.</p>
+
+  <h3 class="h6 mt-4 mb-2">b) Usage data (analytics)</h3>
+  <p>We use <strong>Plausible Analytics</strong> to understand how visitors use our site. Plausible is a privacy-first analytics tool that does not use cookies, does not track you across websites, and does not collect any personally identifiable information. The data collected (page views, referrer sources, browser type, country-level location) is fully anonymised and aggregated.</p>
+  <p>You can learn more about Plausible's approach to privacy at <a href="https://plausible.io/privacy" target="_blank" rel="noopener">plausible.io/privacy</a>.</p>
+
+  <h3 class="h6 mt-4 mb-2">c) Search queries</h3>
+  <p>When you search for flights, we pass your selected origin airport and travel dates to our flight data provider (Travelpayouts / Aviasales) to retrieve live pricing. We do not store these search queries ourselves or associate them with you individually.</p>
+
+  <h3 class="h6 mt-4 mb-2">d) Location data</h3>
+  <p>We use a third-party IP geolocation service (<strong>ipapi.co</strong>) to automatically detect your approximate country. This is used to pre-fill your likely home region and show relevant flight deals by default. We do not store your IP address, and ipapi.co does not receive any personal identifiers beyond your IP address, which is a standard part of any web request. See <a href="https://ipapi.co/privacy/" target="_blank" rel="noopener">ipapi.co's privacy policy</a> for details.</p>
+
+  <h2 class="h4 mt-5 mb-3">2. Cookies</h2>
+  <p>GetMeOutOfHere.Live does not use first-party tracking cookies. Our analytics provider (Plausible) is cookieless by design.</p>
+  <p>Third-party services embedded on or linked from our site (such as Travelpayouts booking partners) may set their own cookies when you visit their pages. We have no control over those cookies — please refer to those services' own privacy policies.</p>
+
+  <h2 class="h4 mt-5 mb-3">3. Third-party services we use</h2>
+  <p>The table below summarises the third-party services that process data in connection with your use of GetMeOutOfHere.Live:</p>
+
+  <div class="table-responsive mt-3 mb-4">
+    <table class="table table-bordered table-sm" style="font-size:0.9rem;">
+      <thead style="background:#f0f4ff;">
+        <tr>
+          <th>Service</th>
+          <th>Purpose</th>
+          <th>Data shared</th>
+          <th>Privacy policy</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Plausible Analytics</strong></td>
+          <td>Website traffic analytics</td>
+          <td>Anonymous page view data, country, referrer</td>
+          <td><a href="https://plausible.io/privacy" target="_blank" rel="noopener">plausible.io/privacy</a></td>
+        </tr>
+        <tr>
+          <td><strong>Travelpayouts / Aviasales</strong></td>
+          <td>Real-time flight pricing</td>
+          <td>Origin airport, travel dates (no personal data)</td>
+          <td><a href="https://www.travelpayouts.com/en/pages/privacy_policy" target="_blank" rel="noopener">travelpayouts.com</a></td>
+        </tr>
+        <tr>
+          <td><strong>Brevo (Sendinblue)</strong></td>
+          <td>Email subscription management</td>
+          <td>Email address (if you subscribe)</td>
+          <td><a href="https://www.brevo.com/legal/privacypolicy/" target="_blank" rel="noopener">brevo.com</a></td>
+        </tr>
+        <tr>
+          <td><strong>ipapi.co</strong></td>
+          <td>Country detection (auto-fill)</td>
+          <td>IP address (standard, not stored by us)</td>
+          <td><a href="https://ipapi.co/privacy/" target="_blank" rel="noopener">ipapi.co/privacy</a></td>
+        </tr>
+        <tr>
+          <td><strong>Google AdSense</strong></td>
+          <td>Display advertising</td>
+          <td>Anonymous browsing data for ad targeting</td>
+          <td><a href="https://policies.google.com/privacy" target="_blank" rel="noopener">policies.google.com</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 class="h4 mt-5 mb-3">4. Affiliate links and booking</h2>
+  <p>When you click a "Book Now" button on our site, you are redirected to a third-party airline or travel booking website. We do not see, collect, or store any payment or personal information you enter on those external sites. Those sites are governed by their own privacy policies.</p>
+  <p>We earn a referral commission from Travelpayouts when a booking is completed via one of these links. This is how we fund the free service.</p>
+
+  <h2 class="h4 mt-5 mb-3">5. How we use your data</h2>
+  <p>We use information we collect solely to:</p>
+  <ul>
+    <li>Operate and improve the flight search functionality</li>
+    <li>Send you flight deal alerts if you have subscribed (email only)</li>
+    <li>Understand aggregate usage patterns to improve the site</li>
+    <li>Detect your approximate region to show relevant deals by default</li>
+  </ul>
+  <p>We do not use your data for advertising profiling, we do not sell it, and we do not share it with any third party except as described in this policy.</p>
+
+  <h2 class="h4 mt-5 mb-3">6. Data retention</h2>
+  <p>Email addresses collected for flight deal subscriptions are retained until you unsubscribe. Anonymous analytics data is retained in aggregate form indefinitely for trend analysis. We do not store flight search queries or IP addresses.</p>
+
+  <h2 class="h4 mt-5 mb-3">7. Your rights</h2>
+  <p>Depending on where you are located, you may have certain rights under applicable data protection law (including GDPR for users in the UK and European Economic Area):</p>
+  <ul>
+    <li><strong>Right to access</strong> — you can ask what personal data we hold about you</li>
+    <li><strong>Right to erasure</strong> — you can ask us to delete your data</li>
+    <li><strong>Right to rectification</strong> — you can ask us to correct inaccurate data</li>
+    <li><strong>Right to unsubscribe</strong> — you can opt out of marketing emails at any time</li>
+  </ul>
+  <p>To exercise any of these rights, please email us at <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a>.</p>
+
+  <h2 class="h4 mt-5 mb-3">8. Security</h2>
+  <p>Our website is served over HTTPS. We take reasonable technical measures to protect the information we hold. However, no internet transmission is completely secure, and we cannot guarantee absolute security.</p>
+
+  <h2 class="h4 mt-5 mb-3">9. Children's privacy</h2>
+  <p>GetMeOutOfHere.Live is not directed at children under the age of 13. We do not knowingly collect personal information from children. If you believe a child has provided us with personal data, please contact us and we will delete it promptly.</p>
+
+  <h2 class="h4 mt-5 mb-3">10. Changes to this policy</h2>
+  <p>We may update this Privacy Policy from time to time. The "Last updated" date at the top of this page will reflect any changes. We encourage you to review this page periodically.</p>
+
+  <h2 class="h4 mt-5 mb-3">11. Contact</h2>
+  <p>For any questions or concerns about this Privacy Policy or our data practices, please contact us:</p>
+  <p><strong>Email:</strong> <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a><br>
+  <strong>Website:</strong> <a href="/contact">getmeoutofhere.live/contact</a></p>
+
 </div>
 {% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,17 +1,80 @@
 {% extends "base.html" %}
 {% block title %}Terms of Use | GetMeOutOfHere.Live{% endblock %}
-{% block meta_description %}Terms of use for GetMeOutOfHere.Live — a free flight finder. Prices are estimates and bookings are handled by our travel partners.{% endblock %}
+{% block meta_description %}Terms of use for GetMeOutOfHere.Live. Read about how our free flight finder works, our affiliate relationships, price accuracy, and your responsibilities when using the site.{% endblock %}
 {% block og_title %}Terms of Use | GetMeOutOfHere.Live{% endblock %}
-{% block og_description %}Terms of use for GetMeOutOfHere.Live — a free flight finder. Prices are estimates and bookings are handled by our travel partners.{% endblock %}
+{% block og_description %}Terms of use for GetMeOutOfHere.Live — a free flight finder. Prices are live estimates; bookings are handled by our travel partners.{% endblock %}
 {% block content %}
-<div class="container py-5">
-  <h1>Terms of Use</h1>
-  <p><strong>GetMeOutOfHere.Live</strong> is a free tool to help you find cheap flights.</p>
+<div class="container py-5" style="max-width: 800px;">
+
+  <h1 class="mb-2">Terms of Use</h1>
+  <p class="text-muted mb-5"><small>Last updated: April 2026</small></p>
+
+  <p>Please read these Terms of Use ("Terms") carefully before using <strong>getmeoutofhere.live</strong> (the "Site"). By accessing or using the Site, you agree to be bound by these Terms. If you do not agree, please do not use the Site.</p>
+
+  <h2 class="h4 mt-5 mb-3">1. About the service</h2>
+  <p>GetMeOutOfHere.Live is a free flight search and discovery tool. It allows users to enter a departure airport and travel dates to view a ranked list of available destinations and corresponding flight prices sourced in real time from third-party travel data providers.</p>
+  <p>We do not sell airline tickets. We do not operate as a travel agency. We are a comparison and discovery tool that redirects users to third-party airlines and booking platforms to complete purchases.</p>
+
+  <h2 class="h4 mt-5 mb-3">2. Price accuracy and availability</h2>
+  <p>All flight prices displayed on GetMeOutOfHere.Live are sourced from live third-party data feeds (via Travelpayouts / Aviasales) and are indicative only. Prices:</p>
   <ul>
-    <li>We don’t sell tickets ourselves — bookings are handled by airlines and travel partners.</li>
-    <li>Prices shown are estimates and may change at any time.</li>
-    <li>We’re not responsible for changes, cancellations, or issues with your booking — those are managed by the travel provider.</li>
+    <li>Are subject to change at any time without notice</li>
+    <li>May vary depending on the date, time, and device you are using</li>
+    <li>May differ from the price shown once you reach the booking partner's website due to taxes, fees, or fare changes</li>
+    <li>Are not guaranteed until a booking is confirmed and paid for directly with the airline or travel provider</li>
   </ul>
-  <p>By using this site, you agree to these terms.</p>
+  <p>We strongly recommend verifying the final price and all booking conditions on the travel partner's website before making any travel plans or purchases.</p>
+
+  <h2 class="h4 mt-5 mb-3">3. Affiliate relationships and commercial disclosure</h2>
+  <p>GetMeOutOfHere.Live participates in the <strong>Travelpayouts</strong> affiliate programme. When you click a "Book Now" or similar link on our Site and complete a booking with an airline or travel provider, we may receive a referral commission from Travelpayouts at no additional cost to you.</p>
+  <p>This commission is how we fund the free service. Our editorial content, flight rankings, and search results are not influenced by affiliate commission rates — results are always sorted by price.</p>
+  <p>Links to external booking sites are clearly identified. We are not responsible for the content, pricing, or policies of those external sites.</p>
+
+  <h2 class="h4 mt-5 mb-3">4. No liability for bookings</h2>
+  <p>GetMeOutOfHere.Live is not a party to any booking, contract, or transaction between you and an airline or travel provider. We have no control over and accept no responsibility for:</p>
+  <ul>
+    <li>The accuracy, availability, or pricing of flights displayed</li>
+    <li>Flight cancellations, delays, or schedule changes</li>
+    <li>The policies of airlines or travel providers regarding refunds, rebooking, or baggage</li>
+    <li>Any loss, damage, or inconvenience arising from a booking made through a link from our Site</li>
+    <li>Technical errors on third-party booking sites</li>
+  </ul>
+  <p>Any dispute relating to a booking must be resolved directly with the airline or travel provider concerned.</p>
+
+  <h2 class="h4 mt-5 mb-3">5. Use of the site</h2>
+  <p>You may use GetMeOutOfHere.Live for personal, non-commercial purposes only. You agree not to:</p>
+  <ul>
+    <li>Use automated tools (bots, scrapers, crawlers) to access or harvest data from the Site without our prior written consent</li>
+    <li>Attempt to circumvent, disable, or interfere with the security or proper functioning of the Site</li>
+    <li>Use the Site for any unlawful purpose or in violation of any applicable laws or regulations</li>
+    <li>Reproduce, republish, or redistribute our content without permission</li>
+  </ul>
+
+  <h2 class="h4 mt-5 mb-3">6. Intellectual property</h2>
+  <p>All content on GetMeOutOfHere.Live — including text, images, code, and design — is owned by or licensed to us. You may not copy, reproduce, or distribute any part of the Site without our express written permission, except as permitted by applicable law (e.g. fair use for personal reference).</p>
+
+  <h2 class="h4 mt-5 mb-3">7. Disclaimer of warranties</h2>
+  <p>GetMeOutOfHere.Live is provided "as is" and "as available" without warranties of any kind, either express or implied, including but not limited to implied warranties of merchantability, fitness for a particular purpose, or non-infringement.</p>
+  <p>We do not warrant that the Site will be uninterrupted, error-free, or free of viruses or other harmful components. We do not warrant the accuracy, completeness, or timeliness of any information on the Site.</p>
+
+  <h2 class="h4 mt-5 mb-3">8. Limitation of liability</h2>
+  <p>To the fullest extent permitted by law, GetMeOutOfHere.Live and its operators shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of (or inability to use) the Site or any bookings made through it — including but not limited to lost profits, lost travel opportunities, or data loss.</p>
+  <p>Our total liability to you for any claim arising from use of the Site shall not exceed the amount you paid to use the Site (which is zero, as the Site is free).</p>
+
+  <h2 class="h4 mt-5 mb-3">9. External links</h2>
+  <p>Our Site contains links to third-party websites, including airlines and travel booking platforms. These links are provided for convenience. We have no control over the content, policies, or practices of external sites and accept no responsibility for them. Visiting external sites is at your own risk.</p>
+
+  <h2 class="h4 mt-5 mb-3">10. Email subscriptions</h2>
+  <p>If you subscribe to flight deal alerts, you consent to receiving occasional emails about flight deals relevant to your selected airport(s). You can unsubscribe at any time using the link in any email or by contacting us at <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a>.</p>
+
+  <h2 class="h4 mt-5 mb-3">11. Changes to these terms</h2>
+  <p>We may update these Terms from time to time. The "Last updated" date at the top of this page will reflect any changes. Continued use of the Site after changes are posted constitutes acceptance of the revised Terms.</p>
+
+  <h2 class="h4 mt-5 mb-3">12. Governing law</h2>
+  <p>These Terms are governed by and construed in accordance with the laws of England and Wales. Any disputes arising from these Terms or your use of the Site will be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+
+  <h2 class="h4 mt-5 mb-3">13. Contact</h2>
+  <p>If you have any questions about these Terms, please contact us at <a href="mailto:hello@getmeoutofhere.live">hello@getmeoutofhere.live</a> or visit our <a href="/contact">contact page</a>.</p>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
…content rejection

- Rewrote About page with full mission, how-it-works steps, data sources, and affiliate disclosure
- Rewrote Privacy Policy with GDPR rights, full third-party services table (Plausible, Travelpayouts, Brevo, ipapi.co, AdSense), cookie policy, and data retention details
- Rewrote Terms of Use with price accuracy disclaimer, affiliate disclosure, liability limitations, IP clause, and governing law (England & Wales)
- Added new /contact page (contact.html + app.py route) with email, FAQ link, and booking issue warning
- Updated nav and footer to link to /contact page instead of bare mailto

https://claude.ai/code/session_01E8xCCqsa9MM2yv63AqsWa6